### PR TITLE
Fix event schema inconsistencies across API contracts

### DIFF
--- a/docs/api-contracts/domain-2-match-service.md
+++ b/docs/api-contracts/domain-2-match-service.md
@@ -195,15 +195,13 @@ DELETE /matches/match-001
   "detail-type": "match.created",
   "detail": {
     "matchId": "match-001",
-    "userAId": "user-123",
-    "userBId": "user-456",
-    "baziScore": 85,
-    "matchedAt": "2026-04-01T12:00:00Z"
+    "userIds": ["user-123", "user-456"],
+    "timestamp": "2026-04-01T12:00:00Z"
   }
 }
 ```
 
-**Consumed by:** Notification Service, Chat Service
+**Consumed by:** Push Notification, Email Service, Icebreaker Service, Activity Logger
 
 ---
 
@@ -213,5 +211,5 @@ DELETE /matches/match-001
 |-----------|---------|-----|
 | **Called by** | Frontend (React) | HTTP via API Gateway |
 | **Consumes from** | Swipe Service | EventBridge `swipe.created` / DynamoDB Stream |
-| **Publishes to** | Notification Service, Chat Service | EventBridge `match.created` |
+| **Publishes to** | Push Notification, Email Service, Icebreaker Service, Activity Logger | EventBridge `match.created` |
 | **Depends on** | Auth (Cognito) | JWT validation via API Gateway Authorizer |

--- a/docs/api-contracts/domain-3-message-service.md
+++ b/docs/api-contracts/domain-3-message-service.md
@@ -231,7 +231,7 @@ Published when a new message is persisted.
 }
 ```
 
-**Consumed by:** Notification Service, Activity Logger
+**Consumed by:** Text Moderation, Activity Logger
 
 ---
 

--- a/docs/api-contracts/domain-4-image-moderation-service.md
+++ b/docs/api-contracts/domain-4-image-moderation-service.md
@@ -168,19 +168,20 @@ GET /moderate/image/history?limit=20&cursor=xxx
 
 ```json
 {
-  "source": "kismet.image-moderation-service",
+  "source": "kismet.moderation",
   "detail-type": "content.flagged",
   "detail": {
-    "photoId": "photo-001",
+    "contentId": "photo-001",
+    "contentType": "image",
     "userId": "user-123",
-    "labels": ["Explicit Nudity"],
-    "confidence": 95.6,
+    "reason": "explicit_nudity",
+    "score": 0.96,
     "timestamp": "2026-04-01T12:00:00Z"
   }
 }
 ```
 
-**Consumed by:** Admin Dashboard
+**Consumed by:** Admin Dashboard, Activity Logger
 
 ---
 

--- a/docs/api-contracts/domain-4-report-service.md
+++ b/docs/api-contracts/domain-4-report-service.md
@@ -222,7 +222,7 @@ GET /reports/report-001
     "reporterId": "user-123",
     "reportedUserId": "user-456",
     "reason": "harassment",
-    "createdAt": "2026-04-01T12:00:00Z"
+    "timestamp": "2026-04-01T12:00:00Z"
   }
 }
 ```

--- a/docs/api-contracts/domain-4-text-moderation-service.md
+++ b/docs/api-contracts/domain-4-text-moderation-service.md
@@ -135,12 +135,15 @@ GET /moderate/text/history?limit=20&cursor=xxx
 
 ```json
 {
-  "source": "kismet.messaging-service",
+  "source": "kismet.message-service",
   "detail-type": "message.sent",
   "detail": {
     "messageId": "msg-123",
+    "matchId": "match-789",
     "senderId": "user-123",
-    "content": "message text"
+    "content": "message text",
+    "messageType": "text",
+    "timestamp": "2026-04-01T12:05:00Z"
   }
 }
 ```
@@ -151,19 +154,20 @@ GET /moderate/text/history?limit=20&cursor=xxx
 
 ```json
 {
-  "source": "kismet.text-moderation-service",
+  "source": "kismet.moderation",
   "detail-type": "content.flagged",
   "detail": {
     "contentId": "msg-123",
-    "contentType": "message",
-    "toxicityScore": 0.87,
-    "categories": ["HATE_SPEECH", "INSULT"],
+    "contentType": "text",
+    "userId": "user-123",
+    "reason": "toxicity_detected",
+    "score": 0.87,
     "timestamp": "2026-04-01T12:00:00Z"
   }
 }
 ```
 
-**Consumed by:** Admin Dashboard
+**Consumed by:** Admin Dashboard, Activity Logger
 
 ---
 
@@ -171,7 +175,7 @@ GET /moderate/text/history?limit=20&cursor=xxx
 
 | Direction | Service | How |
 |-----------|---------|-----|
-| **Called by** | EventBridge (message.sent) | 自动触发审核 |
+| **Called by** | EventBridge (`message.sent`) | 自动触发审核 |
 | **Publishes to** | Admin Dashboard | EventBridge `content.flagged` |
 | **Depends on** | AWS Comprehend | DetectToxicContent API |
 | **Depends on** | Auth (Cognito) | JWT validation（GET 端点，管理员权限） |

--- a/docs/api-contracts/domain-5-email-service.md
+++ b/docs/api-contracts/domain-5-email-service.md
@@ -189,8 +189,7 @@ Triggers sending a match notification email (if user has matchNotifications enab
   "detail-type": "match.created",
   "detail": {
     "matchId": "match-001",
-    "userId1": "user-123",
-    "userId2": "user-456",
+    "userIds": ["user-123", "user-456"],
     "timestamp": "2026-04-01T12:00:00Z"
   }
 }

--- a/docs/api-contracts/domain-5-event-bus-service.md
+++ b/docs/api-contracts/domain-5-event-bus-service.md
@@ -86,8 +86,7 @@ GET /events/history?source=kismet.match-service&detailType=match.created&limit=2
       "detailType": "match.created",
       "detail": {
         "matchId": "match-001",
-        "userId1": "user-123",
-        "userId2": "user-456"
+        "userIds": ["user-123", "user-456"]
       },
       "timestamp": "2026-04-01T12:00:00Z",
       "status": "delivered"

--- a/docs/api-contracts/domain-5-push-notification-service.md
+++ b/docs/api-contracts/domain-5-push-notification-service.md
@@ -207,8 +207,7 @@ Triggers a push notification: "You have a new match!"
   "detail-type": "match.created",
   "detail": {
     "matchId": "match-001",
-    "userId1": "user-123",
-    "userId2": "user-456",
+    "userIds": ["user-123", "user-456"],
     "timestamp": "2026-04-01T12:00:00Z"
   }
 }
@@ -220,13 +219,14 @@ Triggers a push notification: "New message from {senderName}"
 
 ```json
 {
-  "source": "kismet.chat-service",
+  "source": "kismet.message-service",
   "detail-type": "message.sent",
   "detail": {
     "messageId": "msg-001",
-    "conversationId": "conv-001",
+    "matchId": "match-789",
     "senderId": "user-123",
-    "recipientId": "user-456",
+    "content": "Hey! Nice to meet you",
+    "messageType": "text",
     "timestamp": "2026-04-01T12:00:00Z"
   }
 }
@@ -249,6 +249,6 @@ Triggers a push notification: "New message from {senderName}"
 |-----------|---------|-----|
 | **Called by** | Frontend (React) | HTTP via API Gateway |
 | **Consumes from** | Match Service | EventBridge `match.created` |
-| **Consumes from** | Chat Service | EventBridge `message.sent` |
+| **Consumes from** | Message Service | EventBridge `message.sent` |
 | **Depends on** | Auth (Cognito) | JWT validation via API Gateway Authorizer |
 | **Uses** | SNS | Push notification delivery |

--- a/docs/api-contracts/domain-6-activity-logger-service.md
+++ b/docs/api-contracts/domain-6-activity-logger-service.md
@@ -101,7 +101,7 @@ GET /analytics/log/recent?userId=user-123&eventType=swipe.created&limit=50
       "userId": "user-123",
       "eventData": {
         "messageId": "msg-001",
-        "chatId": "chat-001"
+        "matchId": "match-789"
       },
       "timestamp": "2026-04-01T11:55:00Z"
     }
@@ -162,7 +162,7 @@ Example event types consumed:
 - `swipe.created`
 - `match.created`
 - `message.sent`
-- `user.registered`
+- `user.created`
 - `content.flagged`
 - `user.reported`
 - (all other events)

--- a/docs/api-contracts/domain-6-admin-dashboard-service.md
+++ b/docs/api-contracts/domain-6-admin-dashboard-service.md
@@ -307,15 +307,14 @@ Adds flagged content to the flagged content queue in DynamoDB.
 
 ```json
 {
-  "source": "kismet.text-moderation-service",
+  "source": "kismet.moderation",
   "detail-type": "content.flagged",
   "detail": {
-    "contentId": "flag-001",
-    "type": "text",
-    "content": "...",
+    "contentId": "msg-001",
+    "contentType": "text",
     "userId": "user-456",
-    "reason": "hate_speech",
-    "confidence": 0.92,
+    "reason": "toxicity_detected",
+    "score": 0.92,
     "timestamp": "2026-04-01T11:30:00Z"
   }
 }
@@ -332,7 +331,7 @@ Increments the report count for the reported user.
   "detail": {
     "reportId": "report-001",
     "reportedUserId": "user-456",
-    "reportedBy": "user-123",
+    "reporterId": "user-123",
     "reason": "harassment",
     "timestamp": "2026-04-01T11:35:00Z"
   }


### PR DESCRIPTION
## Summary
- Align all 10 affected API contract files with `event-schema.json` (the single source of truth)
- Fix field names: `userId1`/`userId2` → `userIds` array, `reportedBy` → `reporterId`, `chatId` → `matchId`
- Fix source names: `kismet.chat-service`/`kismet.messaging-service` → `kismet.message-service`
- Unify `content.flagged` event format: `contentId`/`contentType`/`reason`/`score` + source `kismet.moderation`
- Standardize timestamp fields: `createdAt`/`matchedAt` → `timestamp`
- Update consumer lists to match event-schema.json

## Context
Audit found 20 inconsistencies between event-schema.json and the 25 API contracts. Domain 5 branches (`email-service`, `push-notification-service`) already adopted `event-schema.json` format, confirming it as authority.

⚠️ **Note for @lingyun**: `d6-analytics` branch uses `reportedBy` (not `reporterId`) and `chatId` (not `matchId`) — these will need updating to match.

## Files changed (10)
- `domain-2-match-service.md` — match.created fields + consumer list
- `domain-3-message-service.md` — consumer list
- `domain-4-text-moderation-service.md` — message.sent source + content.flagged fields
- `domain-4-image-moderation-service.md` — content.flagged fields
- `domain-4-report-service.md` — timestamp field
- `domain-5-push-notification-service.md` — match.created + message.sent fields
- `domain-5-email-service.md` — match.created fields
- `domain-5-event-bus-service.md` — match.created fields
- `domain-6-activity-logger-service.md` — event names + field names
- `domain-6-admin-dashboard-service.md` — content.flagged + user.reported fields

## Test plan
- [x] Grep for old field names (`userId1`, `userId2`, `userAId`, `chatId`, `reportedBy`, `chat-service`, `messaging-service`) — should find 0 matches in event sections
- [x] Each contract's EventBridge section matches its entry in `event-schema.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)