### PR TITLE
docs: team update + Redis rate limiter + README cleanup

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -95,7 +95,7 @@ The app is built entirely on AWS using a **serverless, event-driven architecture
 **Key architectural decisions:**
 - **Serverless-first:** All compute runs on AWS Lambda — no servers to manage
 - **Event-driven:** Domains communicate asynchronously via EventBridge, reducing coupling
-- **Real-time:** WebSocket API Gateway for chat; ElastiCache for presence
+- **Real-time:** WebSocket API Gateway for chat; DynamoDB TTL for presence; ElastiCache (Redis) for rate limiting
 - **AI/ML native:** Rekognition (image moderation), Comprehend (text moderation), Bedrock (icebreakers)
 
 ---
@@ -108,16 +108,16 @@ The app is built entirely on AWS using a **serverless, event-driven architecture
 |---------|-------|-------------|-------------|
 | Auth Service | Quinn Gao | Cognito, Lambda | Sign up, login, JWT tokens |
 | Profile Service | Quinn Gao | Lambda, DynamoDB | CRUD for user profiles |
-| Photo Service | Zhiping | S3, Lambda, CloudFront | Upload, resize, serve photos |
-| Email Verification | Zhiping | SES, Lambda, Cognito | .edu email verification |
+| Photo Service | KS | S3, Lambda, CloudFront | Upload, resize, serve photos |
+| Email Verification | KS | SES, Lambda, Cognito | .edu email verification |
 
 ### Domain 2 — Discovery & Matching
 
 | Service | Owner | AWS Services | Description |
 |---------|-------|-------------|-------------|
-| Discovery Service | Hao | Lambda, DynamoDB | Filter and browse candidates |
-| Swipe Service | Hao | Lambda, DynamoDB | Record like/pass actions |
-| Match Service | Hao | Lambda, DynamoDB Streams, SNS | Detect mutual likes |
+| Discovery Service | Qinyuan | Lambda, DynamoDB | Filter and browse candidates |
+| Swipe Service | Qinyuan | Lambda, DynamoDB | Record like/pass actions |
+| Match Service | Qinyuan | Lambda, DynamoDB Streams, SNS | Detect mutual likes |
 | Recommendation Service | Qinyuan | Lambda, DynamoDB | Score and rank candidates |
 | BaZi Service | Qinyuan | Lambda | BaZi compatibility via external API |
 
@@ -127,7 +127,7 @@ The app is built entirely on AWS using a **serverless, event-driven architecture
 |---------|-------|-------------|-------------|
 | Chat Gateway | Parker | API Gateway WebSocket, Lambda | Real-time message routing |
 | Message Service | Parker | Lambda, DynamoDB | Persist and retrieve chats |
-| Presence Service | QX | ElastiCache, Lambda | Online/offline/typing status |
+| Presence Service | QX | DynamoDB TTL, Lambda | Online/offline/typing status |
 | Icebreaker Service | Jiaxin | Bedrock, Lambda | AI conversation starters |
 
 ### Domain 4 — Safety & Moderation
@@ -135,9 +135,9 @@ The app is built entirely on AWS using a **serverless, event-driven architecture
 | Service | Owner | AWS Services | Description |
 |---------|-------|-------------|-------------|
 | Text Moderation | Yue | Comprehend, Lambda | Flag toxic content |
-| Image Moderation | KS | Rekognition, Lambda | Block inappropriate photos |
+| Image Moderation | Yue | Rekognition, Lambda | Block inappropriate photos |
 | Report Service | Amber | Lambda, DynamoDB, SES | User reports with admin alerts |
-| Rate Limiter | Amber | API Gateway, ElastiCache | Anti-spam protection |
+| Rate Limiter | Amber | API Gateway, ElastiCache (Redis) | Anti-spam protection |
 
 ### Domain 5 — Notifications & Engagement
 
@@ -220,7 +220,7 @@ The app is built entirely on AWS using a **serverless, event-driven architecture
 | Database | DynamoDB, DynamoDB Streams |
 | Storage | S3 |
 | CDN | CloudFront |
-| Caching | ElastiCache (Redis) |
+| Caching / Rate Limiting | ElastiCache (Redis) |
 | AI/ML | Rekognition, Comprehend, Bedrock |
 | Messaging | SNS, SES |
 | Event-Driven | EventBridge, EventBridge Scheduler |
@@ -248,18 +248,18 @@ The app is built entirely on AWS using a **serverless, event-driven architecture
 
 ## 10. Team & Ownership
 
-**14 team members** across 6 domains + integration + PM/frontend.
+**12 team members** across 6 domains + integration + PM/frontend.
 
 | Role | Members |
 |------|---------|
 | **PM / Architect / Frontend** | Qinyuan |
-| **Domain 1 — Identity & Profiles** | Quinn Gao, Zhiping |
-| **Domain 2 — Discovery & Matching** | Qinyuan, Hao |
+| **Domain 1 — Identity & Profiles** | Quinn Gao, KS |
+| **Domain 2 — Discovery & Matching** | Qinyuan |
 | **Domain 3 — Messaging** | Parker, QX, Jiaxin |
 | **Domain 4 — Safety & Moderation** | Yue, KS, Amber |
 | **Domain 5 — Notifications** | Nili, Xiaoyuan |
 | **Domain 6 — Analytics & Admin** | Jessica, Lingyun |
-| **Integration Team** | Zhiping, QX, KS |
+| **Integration Team** | QX, KS |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ A microservice dating app built on AWS — with BaZi (八字) compatibility matc
 
 | Domain | Members | Services |
 |--------|---------|----------|
-| **Identity & Profiles** | Quinn Gao, Zhiping | Auth, Profile, Photo, Email Verification |
-| **Discovery & Matching** | Qinyuan, Hao | Discovery, Swipe, Match, Recommendation, BaZi |
+| **Identity & Profiles** | Quinn Gao, KS | Auth, Profile, Photo, Email Verification |
+| **Discovery & Matching** | Qinyuan | Discovery, Swipe, Match, Recommendation, BaZi |
 | **Messaging** | Parker, QX, Jiaxin | Chat Gateway, Message, Presence, Icebreaker |
-| **Safety & Moderation** | Yue, KS, Amber | Text Moderation, Image Moderation, Report, Rate Limiter |
+| **Safety & Moderation** | Yue, Amber | Text Moderation, Image Moderation, Report, Rate Limiter |
 | **Notifications** | Nili, Xiaoyuan | Push Notification, Email, Event Bus, Scheduler |
 | **Analytics & Admin** | Jessica, Lingyun | Activity Logger, Analytics Pipeline, Admin Dashboard, Health Monitor |
-| **Integration** | Zhiping, QX, KS | Cross-domain service orchestration |
+| **Integration** | QX, KS | Cross-domain service orchestration |
 | **PM / Frontend** | Qinyuan | Architecture, frontend (AI-generated), coordination |
 
 ---
@@ -68,9 +68,9 @@ A microservice dating app built on AWS — with BaZi (八字) compatibility matc
 
 | Service | Owner | AWS Services | Description |
 |---------|-------|-------------|-------------|
-| Discovery Service | Hao | Lambda, DynamoDB | Filter and browse candidates |
-| Swipe Service | Hao | Lambda, DynamoDB | Record like/pass actions |
-| Match Service | Hao | Lambda, DynamoDB Streams, SNS | Detect mutual likes |
+| Discovery Service | Qinyuan | Lambda, DynamoDB | Filter and browse candidates |
+| Swipe Service | Qinyuan | Lambda, DynamoDB | Record like/pass actions |
+| Match Service | Qinyuan | Lambda, DynamoDB Streams, SNS | Detect mutual likes |
 | Recommendation Service | Qinyuan | Lambda, DynamoDB | Score and rank candidates |
 | BaZi Service | Qinyuan | Lambda | 八字 compatibility via external API |
 
@@ -90,7 +90,7 @@ A microservice dating app built on AWS — with BaZi (八字) compatibility matc
 | Text Moderation | Yue | Comprehend, Lambda | Flag toxic content |
 | Image Moderation | Yue | Rekognition, Lambda | Block inappropriate photos |
 | Report Service | Amber | Lambda, DynamoDB, SES | User reports → admin alerts |
-| Rate Limiter | Amber | API Gateway, DynamoDB | Anti-spam protection |
+| Rate Limiter | Amber | API Gateway, ElastiCache (Redis) | Anti-spam protection |
 
 ### Domain 5 — Notifications & Engagement
 
@@ -122,7 +122,7 @@ A microservice dating app built on AWS — with BaZi (八字) compatibility matc
 | Database | DynamoDB, DynamoDB Streams |
 | Storage | S3 |
 | CDN | CloudFront |
-| Caching | DynamoDB TTL (ElastiCache removed) |
+| Caching / Rate Limiting | ElastiCache (Redis) |
 | AI/ML | Rekognition, Comprehend, Bedrock |
 | Messaging | SNS, SES |
 | Event-Driven | EventBridge, EventBridge Scheduler |
@@ -138,12 +138,35 @@ A microservice dating app built on AWS — with BaZi (八字) compatibility matc
 ```
 kismet/
 ├── README.md
+├── PRD.md
+│
 ├── docs/
-│   ├── PRD.md
-│   ├── api-contracts/          ← one file per service
-│   ├── system-design/          ← architecture & infra design docs
-│   └── guides/                 ← setup guide, communication guide, templates
-├── frontend/
+│   ├── api-contracts/                ← one API contract per service (25 files)
+│   ├── system-design/
+│   │   ├── Design_Doc.md             ← high-level architecture & decisions
+│   │   ├── Infrastructure_Design.md  ← AWS resource details
+│   │   ├── CDK_Migration_Plan.md     ← CDK migration guide
+│   │   └── event-schema.json         ← canonical EventBridge event schemas
+│   └── guides/
+│       ├── Kismet_Setup_Guide.md     ← dev environment setup
+│       ├── Service_Communication_Guide.md
+│       └── SERVICE_README_TEMPLATE.md
+│
+├── infra/                            ← AWS CDK (Python)
+│   ├── app.py                        ← CDK entry point
+│   ├── cdk.json
+│   ├── requirements.txt
+│   ├── kismet_constructs/
+│   │   └── kismet_service.py         ← reusable KismetService construct
+│   └── stacks/
+│       ├── shared_stack.py           ← Cognito, API GW, EventBridge, S3, Kinesis, SNS
+│       ├── domain1_stack.py          ← Identity & Profiles
+│       ├── domain2_stack.py          ← Discovery & Matching
+│       ├── domain3_stack.py          ← Messaging
+│       ├── domain4_stack.py          ← Safety & Moderation
+│       ├── domain5_stack.py          ← Notifications & Engagement
+│       └── domain6_stack.py          ← Analytics & Admin
+│
 ├── services/
 │   ├── domain-1-identity/
 │   │   ├── auth-service/
@@ -176,18 +199,31 @@ kismet/
 │       ├── analytics-pipeline-service/
 │       ├── admin-dashboard-service/
 │       └── health-monitor-service/
-└── infra/
+│
+└── frontend/                         ← React app (AI-generated)
 ```
+
+Each service follows the same structure:
+```
+service-name/
+├── lambda_function.py      ← handler function: handler(event, context)
+├── requirements.txt
+├── tests/
+│   └── test_lambda_function.py
+└── README.md
+```
+
 
 ---
 
 ## Git Workflow
 
-- `main` — stable, deployable
-- `dev` — integration branch
+- `main` — stable, deployable (branch protection enabled)
 - `domain-N/service-name` — feature branches
 
-**PR flow:** your branch → `dev` (1 review from domain partner) → `main` (PM merges)
+**PR flow:** feature branch → PR to `main` → 1 review required → merge
+
+> `main` has branch protection: direct push disabled, at least 1 approving review required.
 
 ---
 

--- a/docs/api-contracts/domain-1-email-verification-service.md
+++ b/docs/api-contracts/domain-1-email-verification-service.md
@@ -1,6 +1,6 @@
 # Email Verification Service — API Contract
 
-**Owner:** Zhiping
+**Owner:** KS
 **Domain:** Identity & Profiles
 **Base Path:** `/verify`
 **AWS Services:** SES, Lambda, Cognito

--- a/docs/api-contracts/domain-1-photo-service.md
+++ b/docs/api-contracts/domain-1-photo-service.md
@@ -1,6 +1,6 @@
 # Photo Service — API Contract
 
-**Owner:** Zhiping
+**Owner:** KS
 **Domain:** Identity & Profiles
 **Base Path:** `/photos`
 **AWS Services:** S3, Lambda, CloudFront

--- a/docs/api-contracts/domain-2-discovery-service.md
+++ b/docs/api-contracts/domain-2-discovery-service.md
@@ -1,6 +1,6 @@
 # Discovery Service — API Contract
 
-**Owner:** Hao
+**Owner:** Qinyuan
 **Domain:** Discovery & Matching
 **Base Path:** `/discovery`
 **AWS Services:** Lambda, DynamoDB

--- a/docs/api-contracts/domain-2-match-service.md
+++ b/docs/api-contracts/domain-2-match-service.md
@@ -1,6 +1,6 @@
 # Match Service — API Contract
 
-**Owner:** Hao
+**Owner:** Qinyuan
 **Domain:** Discovery & Matching
 **Base Path:** `/matches`
 **AWS Services:** Lambda, DynamoDB Streams, SNS

--- a/docs/api-contracts/domain-2-swipe-service.md
+++ b/docs/api-contracts/domain-2-swipe-service.md
@@ -1,6 +1,6 @@
 # Swipe Service — API Contract
 
-**Owner:** Hao
+**Owner:** Qinyuan
 **Domain:** Discovery & Matching
 **Base Path:** `/swipe`
 **AWS Services:** Lambda, DynamoDB

--- a/docs/system-design/CDK_Migration_Plan.md
+++ b/docs/system-design/CDK_Migration_Plan.md
@@ -284,7 +284,7 @@ class Domain2Stack(Stack):
     def __init__(self, scope, id, *, shared: SharedStack, **kwargs):
         super().__init__(scope, id, **kwargs)
 
-        # --- Hao 的 services ---
+        # --- Qinyuan 的 services ---
 
         KismetService(self, 'DiscoveryService',
             service_name='discovery',
@@ -507,7 +507,7 @@ usage_plan = api.add_usage_plan('RateLimitPlan',
 )
 ```
 
-加上 DynamoDB TTL 的 per-user 限流逻辑在 Lambda middleware 中实现。
+Rate Limiter 的 per-user 限流通过 ElastiCache (Redis) 实现，见 Rate Limiter Service 配置。
 
 ### 7.9 Push Notification Service — 需要 SNS 权限
 
@@ -546,7 +546,7 @@ KismetService(self, 'EmailService',
 ### 他们看到的：
 
 ```python
-# stacks/domain2_stack.py — Hao 需要做的事：
+# stacks/domain2_stack.py — Qinyuan 需要做的事：
 
 # 1. 确认自己 service 的配置（路由、表结构、事件）
 KismetService(self, 'SwipeService',
@@ -592,10 +592,10 @@ cdk bootstrap                    ← PM 执行一次（初始化 CDK 环境）
 cdk deploy KismetShared          ← PM 部署共享资源
     │                               （Cognito, API GW, EventBridge, S3）
     │
-    ├──→ cdk deploy KismetDomain1   ← Quinn Gao, Zhiping
-    ├──→ cdk deploy KismetDomain2   ← Hao, Qinyuan
+    ├──→ cdk deploy KismetDomain1   ← Quinn Gao, KS
+    ├──→ cdk deploy KismetDomain2   ← Qinyuan
     ├──→ cdk deploy KismetDomain3   ← Parker, QX, Jiaxin
-    ├──→ cdk deploy KismetDomain4   ← Yue, KS, Amber
+    ├──→ cdk deploy KismetDomain4   ← Yue, Amber
     ├──→ cdk deploy KismetDomain5   ← Nili, Xiaoyuan
     └──→ cdk deploy KismetDomain6   ← Jessica, Lingyun
               │

--- a/docs/system-design/Design_Doc.md
+++ b/docs/system-design/Design_Doc.md
@@ -83,7 +83,7 @@ Built entirely on AWS using a serverless, event-driven architecture: **25 micros
 | Text Moderation | Comprehend, Lambda | Detect toxic messages |
 | Image Moderation | Rekognition, Lambda | Block inappropriate photos |
 | Report Service | Lambda, DynamoDB, SES | User reports with admin email alerts |
-| Rate Limiter | API Gateway, DynamoDB TTL | Anti-spam throttling |
+| Rate Limiter | API Gateway, ElastiCache (Redis) | Anti-spam throttling |
 
 ### Domain 5 — Notifications & Engagement
 
@@ -198,9 +198,9 @@ Key tables:
 | `kismet-activity-log` | Activity Logger | `USER#{userId}` | `EVENT#{timestamp}` |
 | `kismet-presence` | Presence | `USER#{userId}` | `STATUS` |
 
-**DynamoDB TTL** is used in two places as a replacement for Redis/ElastiCache:
-- Presence: status expires after 60s (user marked offline if no heartbeat)
-- Rate Limiter: sliding window keys expire automatically
+**DynamoDB TTL** is used for Presence Service: status expires after 60s (user marked offline if no heartbeat).
+
+**ElastiCache (Redis)** is used for Rate Limiter: per-user sliding window counters with automatic expiration via Redis TTL.
 
 ---
 
@@ -249,7 +249,7 @@ Deployment order: SharedStack first, then all domain stacks (can deploy in paral
 
 | Decision | Choice | Reason |
 |----------|--------|--------|
-| Caching | DynamoDB TTL (no Redis) | ElastiCache requires VPC + NAT Gateway; cost and complexity not worth it |
+| Rate Limiting | ElastiCache (Redis) + API Gateway | Redis for per-user limits; Presence still uses DynamoDB TTL |
 | Chat transport | HTTP polling first, WebSocket if time permits | De-risks Week 2; same Message Service backend either way |
 | Analytics ingestion | Kinesis Data Stream → Firehose → S3 → Athena | Course requirement; fallback: direct S3 write |
 | AI icebreakers | Bedrock (fallback: hardcoded templates) | Bedrock access may be delayed |

--- a/docs/system-design/Infrastructure_Design.md
+++ b/docs/system-design/Infrastructure_Design.md
@@ -115,21 +115,18 @@ Rules are managed per-service (each service creates its own EventBridge rule to 
 | Frontend | `kismet-frontend` S3 bucket | Serve React app |
 | Photos | `kismet-photos` S3 bucket | Serve user photos with caching |
 
-### ~~2.6 ElastiCache (Redis)~~ → Replaced by DynamoDB TTL
+### 2.6 ElastiCache (Redis)
 
-> **Decision (2026-04-01):** ElastiCache 已从架构中移除。
-> 原因：需要 VPC + NAT Gateway，配置复杂度高、有额外费用（~$32/月），投入产出比差。
-> Presence Service 和 Rate Limiter 改用 DynamoDB + TTL 实现。
+| Resource | Purpose |
+|----------|---------|
+| **ElastiCache Cluster** | `kismet-redis` — Rate Limiter per-user sliding window counters |
 
-**Presence — DynamoDB with TTL:**
-- Table: `kismet-presence` (PK: `USER#{userId}`, SK: `STATUS`)
-- TTL 字段：60 秒后自动过期 → 用户自动标记为 offline
-- 前端每 30 秒发一次 `POST /presence/heartbeat`
+**Rate Limiting — ElastiCache (Redis) + API Gateway Throttling:**
+- Key format: `ratelimit:{userId}:{action}:{windowTimestamp}`
+- Redis `INCR` + `EX`/`PX` 实现滑动窗口自动过期
+- 结合 API Gateway Usage Plans（基础防护）
 
-**Rate Limiting — DynamoDB with TTL + API Gateway Throttling:**
-- Table: `kismet-rate-limits` (PK: `USER#{userId}#ACTION#{action}`, SK: `WINDOW#{timestamp}`)
-- TTL 字段：滑动窗口过期
-- 结合 API Gateway 自带的 throttle 设置（基础防护）
+> **Note:** ElastiCache 需要 VPC + NAT Gateway。Presence Service 仍使用 DynamoDB TTL。
 
 ### 2.7 Kinesis (Analytics Pipeline)
 
@@ -307,9 +304,9 @@ This way:
 
 If the team hits blockers, here are drop-in simplifications:
 
-### ~~ElastiCache → DynamoDB TTL~~ (已执行)
+### ElastiCache (Redis) for Rate Limiter
 
-已在 §2.6 中正式移除 ElastiCache，改用 DynamoDB TTL。不再是备选方案，而是默认方案。
+Rate Limiter 使用 ElastiCache (Redis) 实现用户级精细限流。需要配置 VPC + NAT Gateway。
 
 ### Kinesis → Direct S3 Write
 
@@ -412,7 +409,7 @@ All resources should stay within AWS free tier or Academy credits:
 | SES | 62K emails/month (from EC2) |
 
 **Watch out for:**
-- **ElastiCache** — NOT free tier. Use DynamoDB TTL alternative if cost-constrained.
+- **ElastiCache** — NOT free tier (~$32/month). Required for Rate Limiter.
 - **Bedrock** — Pay per token. Use sparingly or mock for development.
 - **Kinesis** — $0.015/shard/hour. Consider the direct-S3 alternative.
 - **NAT Gateway** — $0.045/hour if using VPC. Avoid if possible.
@@ -423,14 +420,19 @@ All resources should stay within AWS free tier or Academy credits:
 
 ```
 infra/
-├── shared/
-│   ├── template.yaml              # SAM template: Cognito, EventBridge, API GW, S3, CloudFront
-│   ├── parameters-dev.json        # Environment-specific config
-│   └── README.md                  # How to deploy shared infra
+├── app.py                         # CDK entry point
+├── kismet_constructs/
+│   └── kismet_service.py          # Reusable KismetService construct
+├── stacks/
+│   ├── shared_stack.py            # Cognito, API GW, EventBridge, S3, Kinesis, SNS
+│   ├── domain1_stack.py           # Identity & Profiles services
+│   ├── domain2_stack.py           # Discovery & Matching services
+│   ├── domain3_stack.py           # Messaging services
+│   ├── domain4_stack.py           # Safety & Moderation services
+│   ├── domain5_stack.py           # Notifications & Engagement services
+│   └── domain6_stack.py           # Analytics & Admin services
 │
 services/domain-X/service-name/
-│   ├── template.yaml              # SAM template: Lambda + DynamoDB + IAM
-│   ├── samconfig.toml             # SAM deploy config (auto-generated)
 │   ├── lambda_function.py
 │   ├── requirements.txt
 │   ├── tests/
@@ -443,10 +445,10 @@ services/domain-X/service-name/
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| IaC Tool | **SAM** | Simplest for Lambda-centric apps; 3-week timeline |
+| IaC Tool | **AWS CDK (Python)** | Migrated from SAM; reusable KismetService construct |
 | API Gateway | **One REST + optional WebSocket** | Single entry point; shared auth |
 | Messaging | **HTTP polling → upgrade to WebSocket if time** | De-risks Week 2; same backend |
-| Caching | **DynamoDB TTL** (ElastiCache removed) | Avoid VPC + NAT Gateway complexity and cost |
+| Rate Limiting | **ElastiCache (Redis)** + API Gateway Usage Plans | Redis for per-user sliding window; API GW for global throttle |
 | Analytics | **Kinesis** (default) / Direct S3 (fallback) | Kinesis is a course requirement |
 | Icebreakers | **Bedrock** (default) / Hardcoded (fallback) | Depends on Bedrock access timing |
 | Environments | **Single `dev` env** | 3-week project, no prod needed |


### PR DESCRIPTION
## Summary
- **Personnel update**: Zhiping → KS (D1 Photo/Email Verification), Hao → Qinyuan (D2 Discovery/Swipe/Match)
- **Rate Limiter**: removed DynamoDB TTL alternative, restored ElastiCache (Redis) as the approach — per Amber's implementation
- **README**: added full project structure, updated git workflow (removed `dev` branch, added branch protection note)
- **Infrastructure_Design**: updated IaC from SAM to CDK, updated infra file structure
- Updated 5 API contract owners, PRD, Design_Doc, CDK_Migration_Plan

## Files changed (10)
- `README.md`, `PRD.md`
- `docs/system-design/Infrastructure_Design.md`, `Design_Doc.md`, `CDK_Migration_Plan.md`
- `docs/api-contracts/domain-1-photo-service.md`, `domain-1-email-verification-service.md`
- `docs/api-contracts/domain-2-discovery-service.md`, `domain-2-swipe-service.md`, `domain-2-match-service.md`

## Test plan
- [x] Grep confirmed zero remaining references to "Zhiping" or "Hao" in all .md files
- [x] Grep confirmed no stale "ElastiCache removed" / "DynamoDB TTL rate limiter" references
- [x] Branch protection verified on `main` (require PR + 1 approval)

🤖 Generated with [Claude Code](https://claude.com/claude-code)