### PR TITLE
fix(infra): reduce shared stack event bus cross-stack dependencies

### DIFF
--- a/infra/stacks/domain1_stack.py
+++ b/infra/stacks/domain1_stack.py
@@ -1,6 +1,6 @@
 import aws_cdk as cdk
 from constructs import Construct
-from aws_cdk import aws_iam as iam
+from aws_cdk import aws_events as events, aws_iam as iam
 
 from stacks.shared_stack import SharedStack
 from kismet_constructs.kismet_service import KismetService
@@ -14,6 +14,12 @@ class Domain1Stack(cdk.Stack):
 
     def __init__(self, scope: Construct, construct_id: str, *, shared: SharedStack, **kwargs):
         super().__init__(scope, construct_id, **kwargs)
+
+        event_bus = events.EventBus.from_event_bus_name(
+            self,
+            "ImportedEventBus",
+            "kismet-events",
+        )
 
         # ── Auth Service (KS) ─────────────────────────────────────────────────
         # signup, login, refresh, logout via Cognito
@@ -56,7 +62,7 @@ class Domain1Stack(cdk.Stack):
             ],
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )
 
         # ── Profile Service (Quinn) ───────────────────────────────────────────
@@ -86,7 +92,7 @@ class Domain1Stack(cdk.Stack):
             },
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )
 
         # ── Email Verification Service (Quinn/KS) ────────────────────────────
@@ -131,7 +137,7 @@ class Domain1Stack(cdk.Stack):
             ],
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )
 
         # ── Photo Service (KS) ───────────────────────────────────────────────
@@ -170,5 +176,5 @@ class Domain1Stack(cdk.Stack):
             ],
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )

--- a/infra/stacks/domain2_stack.py
+++ b/infra/stacks/domain2_stack.py
@@ -1,6 +1,6 @@
 import aws_cdk as cdk
 from constructs import Construct
-from aws_cdk import aws_iam as iam
+from aws_cdk import aws_events as events, aws_iam as iam
 
 from stacks.shared_stack import SharedStack
 from kismet_constructs.kismet_service import KismetService
@@ -14,6 +14,12 @@ class Domain2Stack(cdk.Stack):
 
     def __init__(self, scope: Construct, construct_id: str, *, shared: SharedStack, **kwargs):
         super().__init__(scope, construct_id, **kwargs)
+
+        event_bus = events.EventBus.from_event_bus_name(
+            self,
+            "ImportedEventBus",
+            "kismet-events",
+        )
 
         # ── Swipe Service ─────────────────────────────────────────────────────
         swipe_svc = KismetService(
@@ -35,7 +41,7 @@ class Domain2Stack(cdk.Stack):
             publish_events=True,
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )
 
         # ── Match Service ─────────────────────────────────────────────────────
@@ -70,7 +76,7 @@ class Domain2Stack(cdk.Stack):
             ],
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )
 
         # ── Discovery Service ─────────────────────────────────────────────────
@@ -104,7 +110,7 @@ class Domain2Stack(cdk.Stack):
             ],
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )
 
         # ── Recommendation Service ────────────────────────────────────────────
@@ -143,7 +149,7 @@ class Domain2Stack(cdk.Stack):
             ],
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )
 
         # ── BaZi Service ─────────────────────────────────────────────────────
@@ -158,5 +164,5 @@ class Domain2Stack(cdk.Stack):
             ],
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )

--- a/infra/stacks/domain5_stack.py
+++ b/infra/stacks/domain5_stack.py
@@ -26,6 +26,12 @@ class Domain5Stack(cdk.Stack):
     def __init__(self, scope: Construct, construct_id: str, *, shared: SharedStack, **kwargs):
         super().__init__(scope, construct_id, **kwargs)
 
+        event_bus = events.EventBus.from_event_bus_name(
+            self,
+            "ImportedEventBus",
+            "kismet-events",
+        )
+
         # ══════════════════════════════════════════════════════════════════════
         # Nili's services (standard KismetService pattern)
         # ══════════════════════════════════════════════════════════════════════
@@ -69,7 +75,7 @@ class Domain5Stack(cdk.Stack):
             },
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )
 
         # ── Email Service ─────────────────────────────────────────────────────
@@ -106,7 +112,7 @@ class Domain5Stack(cdk.Stack):
             },
             api=shared.api,
             authorizer=shared.authorizer,
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
         )
 
         # ══════════════════════════════════════════════════════════════════════
@@ -139,7 +145,7 @@ class Domain5Stack(cdk.Stack):
 
         event_bus_env = {
             "EVENT_LOG_TABLE": event_log_table.table_name,
-            "EVENT_BUS_NAME": shared.event_bus.event_bus_name,
+            "EVENT_BUS_NAME": event_bus.event_bus_name,
             "ENVIRONMENT": "dev",
         }
 
@@ -164,7 +170,7 @@ class Domain5Stack(cdk.Stack):
             self,
             "CatchAllRule",
             rule_name="kismet-catch-all-logger",
-            event_bus=shared.event_bus,
+            event_bus=event_bus,
             event_pattern=events.EventPattern(
                 source=events.Match.prefix("kismet."),
             ),
@@ -186,7 +192,7 @@ class Domain5Stack(cdk.Stack):
         )
 
         event_log_table.grant_read_write_data(admin_events_fn)
-        shared.event_bus.grant_put_events_to(admin_events_fn)  # for replay
+        event_bus.grant_put_events_to(admin_events_fn)  # for replay
 
         admin_events_fn.add_to_role_policy(
             iam.PolicyStatement(
@@ -196,8 +202,8 @@ class Domain5Stack(cdk.Stack):
                     "events:DescribeRule",
                 ],
                 resources=[
-                    f"arn:aws:events:{self.region}:{self.account}:rule/{shared.event_bus.event_bus_name}/*",
-                    shared.event_bus.event_bus_arn,
+                    f"arn:aws:events:{self.region}:{self.account}:rule/{event_bus.event_bus_name}/*",
+                    event_bus.event_bus_arn,
                 ],
             )
         )
@@ -239,14 +245,14 @@ class Domain5Stack(cdk.Stack):
             memory_size=256,
             environment={
                 "SCHEDULER_TABLE": scheduler_table.table_name,
-                "EVENT_BUS_NAME": shared.event_bus.event_bus_name,
+                "EVENT_BUS_NAME": event_bus.event_bus_name,
                 "ENVIRONMENT": "dev",
             },
             log_retention=logs.RetentionDays.ONE_WEEK,
         )
 
         scheduler_table.grant_read_write_data(executor_fn)
-        shared.event_bus.grant_put_events_to(executor_fn)
+        event_bus.grant_put_events_to(executor_fn)
 
         # IAM Role for EventBridge Scheduler to invoke executor Lambda
         scheduler_role = iam.Role(
@@ -320,7 +326,7 @@ class Domain5Stack(cdk.Stack):
             memory_size=256,
             environment={
                 "SCHEDULER_TABLE": scheduler_table.table_name,
-                "EVENT_BUS_NAME": shared.event_bus.event_bus_name,
+                "EVENT_BUS_NAME": event_bus.event_bus_name,
                 "ENVIRONMENT": "dev",
                 "JOB_EXECUTOR_ARN": executor_fn.function_arn,
                 "SCHEDULER_ROLE_ARN": scheduler_role.role_arn,


### PR DESCRIPTION
## Summary
This PR continues the shared CDK cycle fix pattern by reducing direct SharedStack EventBridge references in Domain 1, Domain 2, and Domain 5.

## What Changed
Updated the following stacks:
* `domain1_stack.py`
* `domain2_stack.py`
* `domain5_stack.py`

In each stack, this PR:
* Imports the shared EventBridge bus by name inside the domain stack.
* Replaces direct `shared.event_bus` usage with the imported bus reference.
* Preserves the existing runtime behavior while reducing cross-stack CloudFormation dependencies.

## Why
We found a recurring circular dependency pattern where:
1. `KismetShared` depends on domain Lambdas through shared API/integration wiring.
2. Domain stacks also depend back on `KismetShared` through direct `shared.event_bus` references.

This creates **Shared -> Domain -> Shared** dependency loops during CDK validation/synth.

## Notes
* This follows the same fix direction already used in Domains 3, 4, and 6.
* This PR is focused only on the EventBridge cross-stack reference cleanup in Domains 1, 2, and 5.
* There may still be separate `SharedStack` cross-stack issues to resolve outside this PR, especially around other shared resources like Cognito.