### PR TITLE
fix(domain3): resolve API Gateway path variable conflicts — closes #83

### DIFF
--- a/infra/stacks/domain3_stack.py
+++ b/infra/stacks/domain3_stack.py
@@ -68,9 +68,9 @@ class Domain3Stack(cdk.Stack):
                 }
             ],
             routes=[
-                {"method": "POST", "path": "/messages", "auth": True},
-                {"method": "GET", "path": "/messages/{matchId}", "auth": True},
-                {"method": "DELETE", "path": "/messages/{messageId}", "auth": True},
+                {"method": "POST",   "path": "/messages",                 "auth": True},
+                {"method": "GET",    "path": "/messages/match/{matchId}", "auth": True},
+                {"method": "DELETE", "path": "/messages/{messageId}",     "auth": True},
             ],
             consume_events=[],   # no incoming events; other services call via HTTP
             publish_events=True, # publishes message.sent
@@ -217,8 +217,8 @@ class Domain3Stack(cdk.Stack):
             code_path="../services/domain-3-messaging/presence-service",
             tables=[],  # created manually above to support TTL
             routes=[
-                {"method": "POST", "path": "/presence/heartbeat", "auth": True},
-                {"method": "GET",  "path": "/presence/{userId}",          "auth": True},
+                {"method": "POST", "path": "/presence/heartbeat",          "auth": True},
+                {"method": "GET",  "path": "/presence/user/{userId}",     "auth": True},
                 {"method": "POST", "path": "/presence/{matchId}/typing",  "auth": True},
                 {"method": "GET",  "path": "/presence/{matchId}/typing",  "auth": True},
             ],


### PR DESCRIPTION
Fixes #83

## What changed
Two API Gateway path variable conflicts prevented `cdk deploy KismetDomain3`.

API Gateway does not allow two different variable names at the same URL level.

**Messages** (`/messages/`):
- `{matchId}` and `{messageId}` were siblings → conflict
- Fix: `GET /messages/{matchId}` → `GET /messages/match/{matchId}`

**Presence** (`/presence/`):
- `{userId}` and `{matchId}` were siblings → conflict  
- Fix: `GET /presence/{userId}` → `GET /presence/user/{userId}`

Lambda handlers are unchanged — path parameter names are the same.
`cdk list` passes locally.