### PR TITLE
add ban-profile-status: profile-service listens to user.banned event

### DIFF
--- a/infra/stacks/domain1_stack.py
+++ b/infra/stacks/domain1_stack.py
@@ -94,56 +94,18 @@ class Domain1Stack(cdk.Stack):
             publish_events=True,
             environment={
                 "PROFILES_TABLE_NAME": "kismet-profiles",
-            },
-            api=imported_api,
-            authorizer=shared.authorizer,
-            event_bus=event_bus,
-        )
-
-        # ── Email Verification Service (Quinn/KS) ────────────────────────────
-        # Send verification code via SES, confirm code, update Cognito
-        email_verify_svc = KismetService(
-            self,
-            "EmailVerificationService",
-            service_name="email-verification",
-            code_path="../services/domain-1-identity/email-verification-service",
-            tables=[
-                {
-                    "table_name": "kismet-verifications",
-                    "pk": {"name": "PK", "type": "S"},
-                    "sk": {"name": "SK", "type": "S"},
-                }
-            ],
-            routes=[
-                {"method": "POST", "path": "/verify/send", "auth": True},
-                {"method": "POST", "path": "/verify/confirm", "auth": True},
-                {"method": "GET", "path": "/verify/status", "auth": True},
-            ],
-            environment={
-                "COGNITO_USER_POOL_ID": shared.user_pool.user_pool_id,
-                "VERIFICATIONS_TABLE_NAME": "kismet-verifications",
-                "SES_SOURCE_EMAIL": "noreply@university.edu",  # TODO: update before deploy
+                "DISCOVERY_TABLE_NAME": "kismet-discovery",
             },
             extra_policies=[
-                # SES for sending verification emails
                 iam.PolicyStatement(
-                    actions=["ses:SendEmail", "ses:SendRawEmail"],
-                    resources=["*"],
-                ),
-                # Cognito for updating email_verified attribute
-                iam.PolicyStatement(
-                    actions=[
-                        "cognito-idp:AdminGetUser",
-                        "cognito-idp:AdminUpdateUserAttributes",
-                    ],
-                    resources=[shared.user_pool.user_pool_arn],
+                    actions=["dynamodb:DeleteItem", "dynamodb:UpdateItem"],
+                    resources=["arn:aws:dynamodb:*:*:table/kismet-discovery"],
                 ),
             ],
             api=imported_api,
             authorizer=shared.authorizer,
             event_bus=event_bus,
         )
-
         # ── Photo Service (KS) ───────────────────────────────────────────────
         # Upload (presigned URL), list, delete, set primary photo
         photo_svc = KismetService(

--- a/services/domain-1-identity/profile-service/lambda_function.py
+++ b/services/domain-1-identity/profile-service/lambda_function.py
@@ -15,6 +15,7 @@ SERVICE_NAME = "profile-service"
 PROFILE_DETAIL_PATTERN = re.compile(r"^/profiles/(?P<userId>[^/]+)$")
 
 PROFILES_TABLE_NAME = os.environ.get("PROFILES_TABLE_NAME", "")
+DISCOVERY_TABLE_NAME = os.environ.get("DISCOVERY_TABLE_NAME", "kismet-discovery")
 EVENT_BUS_NAME = os.environ.get("EVENT_BUS_NAME", "")
 
 dynamodb = boto3.resource("dynamodb")
@@ -27,6 +28,10 @@ VALID_INTERESTED_IN = {"male", "female", "non-binary", "everyone"}
 
 def handler(event, context):
     event = event or {}
+    if event.get("source") == "kismet.report-service":
+        if event.get("detail-type") == "user.banned":
+            return handle_user_banned(event)
+
     method = _get_method(event)
     path = _get_path(event)
     user_id = _get_user_id(event)
@@ -128,6 +133,9 @@ def handle_get(user_id: str) -> Dict[str, Any]:
 
     if not item:
         return _response(404, {"code": "NOT_FOUND", "message": "Profile not found."})
+    
+    if item.get("status") == "banned":
+        return _response(404, {"code": "NOT_FOUND", "message": "Profile not found."})
 
     profile = {k: v for k, v in item.items() if k not in ("PK", "SK")}
     return _response(200, profile)
@@ -193,6 +201,32 @@ def handle_delete(caller_id: str, user_id: str) -> Dict[str, Any]:
 
     table.delete_item(Key={"PK": f"USER#{user_id}", "SK": "PROFILE"})
     return _response(200, {"message": "Profile deleted successfully"})
+
+def handle_user_banned(event: Dict[str, Any]) -> Dict[str, Any]:
+    detail = event.get("detail", {})
+    if isinstance(detail, str):
+        detail = json.loads(detail)
+
+    user_id = detail.get("userId")
+    if not user_id:
+        logger.warning("user.banned event missing userId")
+        return {"statusCode": 400, "body": "Missing userId"}
+
+    # 1. 标记 profile 为 banned
+    dynamodb.Table(PROFILES_TABLE_NAME).update_item(
+        Key={"PK": f"USER#{user_id}", "SK": "PROFILE"},
+        UpdateExpression="SET #status = :banned",
+        ExpressionAttributeNames={"#status": "status"},
+        ExpressionAttributeValues={":banned": "banned"},
+    )
+
+    # 2. 从 discovery 池里删掉这个用户
+    dynamodb.Table(DISCOVERY_TABLE_NAME).delete_item(
+        Key={"PK": f"PROFILE#{user_id}", "SK": "META"}
+    )
+
+    logger.info("User banned and removed from discovery: %s", user_id)
+    return {"statusCode": 200, "body": "User banned"}
 
 
 def _build_event_detail(item: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
profile-service listens to user.banned EventBridge event from report-service
On ban: marks profile status: banned + deletes user from kismet-discovery table
GET /profiles/{userId} returns 404 for banned users