### PR TITLE
Domain 1/ban profile status

### DIFF
--- a/infra/stacks/domain1_stack.py
+++ b/infra/stacks/domain1_stack.py
@@ -98,8 +98,14 @@ class Domain1Stack(cdk.Stack):
             },
             extra_policies=[
                 iam.PolicyStatement(
-                    actions=["dynamodb:DeleteItem", "dynamodb:UpdateItem"],
-                    resources=["arn:aws:dynamodb:*:*:table/kismet-discovery"],
+                    actions=["dynamodb:DeleteItem"],
+                    resources=[
+                        self.format_arn(
+                            service="dynamodb",
+                            resource="table",
+                            resource_name="kismet-discovery",
+                        )
+                    ],
                 ),
             ],
             api=imported_api,

--- a/infra/stacks/domain1_stack.py
+++ b/infra/stacks/domain1_stack.py
@@ -94,56 +94,18 @@ class Domain1Stack(cdk.Stack):
             publish_events=True,
             environment={
                 "PROFILES_TABLE_NAME": "kismet-profiles",
-            },
-            api=imported_api,
-            authorizer=shared.authorizer,
-            event_bus=event_bus,
-        )
-
-        # ── Email Verification Service (Quinn/KS) ────────────────────────────
-        # Send verification code via SES, confirm code, update Cognito
-        email_verify_svc = KismetService(
-            self,
-            "EmailVerificationService",
-            service_name="email-verification",
-            code_path="../services/domain-1-identity/email-verification-service",
-            tables=[
-                {
-                    "table_name": "kismet-verifications",
-                    "pk": {"name": "PK", "type": "S"},
-                    "sk": {"name": "SK", "type": "S"},
-                }
-            ],
-            routes=[
-                {"method": "POST", "path": "/verify/send", "auth": True},
-                {"method": "POST", "path": "/verify/confirm", "auth": True},
-                {"method": "GET", "path": "/verify/status", "auth": True},
-            ],
-            environment={
-                "COGNITO_USER_POOL_ID": shared.user_pool.user_pool_id,
-                "VERIFICATIONS_TABLE_NAME": "kismet-verifications",
-                "SES_SOURCE_EMAIL": "noreply@university.edu",  # TODO: update before deploy
+                "DISCOVERY_TABLE_NAME": "kismet-discovery",
             },
             extra_policies=[
-                # SES for sending verification emails
                 iam.PolicyStatement(
-                    actions=["ses:SendEmail", "ses:SendRawEmail"],
-                    resources=["*"],
-                ),
-                # Cognito for updating email_verified attribute
-                iam.PolicyStatement(
-                    actions=[
-                        "cognito-idp:AdminGetUser",
-                        "cognito-idp:AdminUpdateUserAttributes",
-                    ],
-                    resources=[shared.user_pool.user_pool_arn],
+                    actions=["dynamodb:DeleteItem", "dynamodb:UpdateItem"],
+                    resources=["arn:aws:dynamodb:*:*:table/kismet-discovery"],
                 ),
             ],
             api=imported_api,
             authorizer=shared.authorizer,
             event_bus=event_bus,
         )
-
         # ── Photo Service (KS) ───────────────────────────────────────────────
         # Upload (presigned URL), list, delete, set primary photo
         photo_svc = KismetService(

--- a/infra/stacks/domain1_stack.py
+++ b/infra/stacks/domain1_stack.py
@@ -130,7 +130,7 @@ class Domain1Stack(cdk.Stack):
             environment={
                 "PHOTOS_TABLE_NAME": "kismet-photos",
                 "PHOTOS_BUCKET_NAME": shared.photos_bucket.bucket_name,
-                "PHOTOS_CDN_BASE_URL": "",  # TODO: add CloudFront URL when available
+                "PHOTOS_CDN_BASE_URL": f"https://{shared.photos_bucket.bucket_name}.s3.{self.region}.amazonaws.com",  # TODO: add CloudFront URL when available
             },
             extra_policies=[
                 # S3 for presigned URL generation and object deletion

--- a/infra/stacks/domain1_stack.py
+++ b/infra/stacks/domain1_stack.py
@@ -91,7 +91,12 @@ class Domain1Stack(cdk.Stack):
                 {"method": "PUT", "path": "/profiles/{userId}", "auth": True},
                 {"method": "DELETE", "path": "/profiles/{userId}", "auth": True},
             ],
-            consume_events=["user.banned"],
+            consume_events=[
+                {
+                    "source": "kismet.report-service",
+                    "detail_type": "user.banned",
+                }
+            ],
             publish_events=True,
             environment={
                 "PROFILES_TABLE_NAME": "kismet-profiles",

--- a/infra/stacks/domain1_stack.py
+++ b/infra/stacks/domain1_stack.py
@@ -72,7 +72,7 @@ class Domain1Stack(cdk.Stack):
         )
 
         # ── Profile Service (Quinn) ───────────────────────────────────────────
-        # CRUD for user profiles, publishes profile.completed
+        # CRUD for user profiles, publishes profile.completed, consumes user.banned
         profile_svc = KismetService(
             self,
             "ProfileService",
@@ -91,6 +91,7 @@ class Domain1Stack(cdk.Stack):
                 {"method": "PUT", "path": "/profiles/{userId}", "auth": True},
                 {"method": "DELETE", "path": "/profiles/{userId}", "auth": True},
             ],
+            consume_events=["user.banned"],
             publish_events=True,
             environment={
                 "PROFILES_TABLE_NAME": "kismet-profiles",

--- a/infra/stacks/domain1_stack.py
+++ b/infra/stacks/domain1_stack.py
@@ -91,12 +91,7 @@ class Domain1Stack(cdk.Stack):
                 {"method": "PUT", "path": "/profiles/{userId}", "auth": True},
                 {"method": "DELETE", "path": "/profiles/{userId}", "auth": True},
             ],
-            consume_events=[
-                {
-                    "source": "kismet.report-service",
-                    "detail_type": "user.banned",
-                }
-            ],
+            consume_events=["user.banned"],
             publish_events=True,
             environment={
                 "PROFILES_TABLE_NAME": "kismet-profiles",

--- a/services/domain-1-identity/profile-service/lambda_function.py
+++ b/services/domain-1-identity/profile-service/lambda_function.py
@@ -28,10 +28,6 @@ VALID_INTERESTED_IN = {"male", "female", "non-binary", "everyone"}
 
 def handler(event, context):
     event = event or {}
-    if event.get("source") == "kismet.report-service":
-        if event.get("detail-type") == "user.banned":
-            return handle_user_banned(event)
-
     method = _get_method(event)
     path = _get_path(event)
     user_id = _get_user_id(event)
@@ -39,6 +35,10 @@ def handler(event, context):
     profile_match = PROFILE_DETAIL_PATTERN.match(path)
 
     try:
+        if event.get("source") == "kismet.report-service":
+            if event.get("detail-type") == "user.banned":
+                operation = "handleUserBanned"
+                return handle_user_banned(event)
         if method == "POST" and path == "/profiles":
             operation = "createProfile"
             payload, error = _parse_body(event)

--- a/services/domain-1-identity/profile-service/lambda_function.py
+++ b/services/domain-1-identity/profile-service/lambda_function.py
@@ -212,7 +212,7 @@ def handle_user_banned(event: Dict[str, Any]) -> Dict[str, Any]:
         logger.warning("user.banned event missing userId")
         return {"statusCode": 400, "body": "Missing userId"}
 
-    # 1. 标记 profile 为 banned
+    # 1. Mark the profile as banned.
     try:
         dynamodb.Table(PROFILES_TABLE_NAME).update_item(
             Key={"PK": f"USER#{user_id}", "SK": "PROFILE"},
@@ -227,7 +227,7 @@ def handle_user_banned(event: Dict[str, Any]) -> Dict[str, Any]:
         else:
             raise
 
-    # 2. 从 discovery 池里删掉这个用户
+    # 2. Remove the user from the discovery pool.
     dynamodb.Table(DISCOVERY_TABLE_NAME).delete_item(
         Key={"PK": f"PROFILE#{user_id}", "SK": "META"}
     )

--- a/services/domain-1-identity/profile-service/lambda_function.py
+++ b/services/domain-1-identity/profile-service/lambda_function.py
@@ -213,12 +213,19 @@ def handle_user_banned(event: Dict[str, Any]) -> Dict[str, Any]:
         return {"statusCode": 400, "body": "Missing userId"}
 
     # 1. 标记 profile 为 banned
-    dynamodb.Table(PROFILES_TABLE_NAME).update_item(
-        Key={"PK": f"USER#{user_id}", "SK": "PROFILE"},
-        UpdateExpression="SET #status = :banned",
-        ExpressionAttributeNames={"#status": "status"},
-        ExpressionAttributeValues={":banned": "banned"},
-    )
+    try:
+        dynamodb.Table(PROFILES_TABLE_NAME).update_item(
+            Key={"PK": f"USER#{user_id}", "SK": "PROFILE"},
+            UpdateExpression="SET #status = :banned",
+            ConditionExpression="attribute_exists(PK)",
+            ExpressionAttributeNames={"#status": "status"},
+            ExpressionAttributeValues={":banned": "banned"},
+        )
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") == "ConditionalCheckFailedException":
+            logger.info("No profile found to ban for user: %s", user_id)
+        else:
+            raise
 
     # 2. 从 discovery 池里删掉这个用户
     dynamodb.Table(DISCOVERY_TABLE_NAME).delete_item(

--- a/services/domain-1-identity/profile-service/lambda_function.py
+++ b/services/domain-1-identity/profile-service/lambda_function.py
@@ -205,7 +205,11 @@ def handle_delete(caller_id: str, user_id: str) -> Dict[str, Any]:
 def handle_user_banned(event: Dict[str, Any]) -> Dict[str, Any]:
     detail = event.get("detail", {})
     if isinstance(detail, str):
-        detail = json.loads(detail)
+        try:
+            detail = json.loads(detail)
+        except json.JSONDecodeError:
+            logger.warning("user.banned event detail is not valid JSON")
+            return {"statusCode": 400, "body": "Malformed event detail"}
 
     user_id = detail.get("userId")
     if not user_id:

--- a/services/domain-1-identity/profile-service/lambda_function.py
+++ b/services/domain-1-identity/profile-service/lambda_function.py
@@ -133,7 +133,6 @@ def handle_get(user_id: str) -> Dict[str, Any]:
 
     if not item:
         return _response(404, {"code": "NOT_FOUND", "message": "Profile not found."})
-    
     if item.get("status") == "banned":
         return _response(404, {"code": "NOT_FOUND", "message": "Profile not found."})
 

--- a/services/domain-1-identity/profile-service/lambda_function.py
+++ b/services/domain-1-identity/profile-service/lambda_function.py
@@ -15,6 +15,7 @@ SERVICE_NAME = "profile-service"
 PROFILE_DETAIL_PATTERN = re.compile(r"^/profiles/(?P<userId>[^/]+)$")
 
 PROFILES_TABLE_NAME = os.environ.get("PROFILES_TABLE_NAME", "")
+DISCOVERY_TABLE_NAME = os.environ.get("DISCOVERY_TABLE_NAME", "kismet-discovery")
 EVENT_BUS_NAME = os.environ.get("EVENT_BUS_NAME", "")
 
 dynamodb = boto3.resource("dynamodb")
@@ -27,6 +28,10 @@ VALID_INTERESTED_IN = {"male", "female", "non-binary", "everyone"}
 
 def handler(event, context):
     event = event or {}
+    if event.get("source") == "kismet.report-service":
+        if event.get("detail-type") == "user.banned":
+            return handle_user_banned(event)
+
     method = _get_method(event)
     path = _get_path(event)
     user_id = _get_user_id(event)
@@ -128,6 +133,9 @@ def handle_get(user_id: str) -> Dict[str, Any]:
 
     if not item:
         return _response(404, {"code": "NOT_FOUND", "message": "Profile not found."})
+    
+    if item.get("status") == "banned":
+        return _response(404, {"code": "NOT_FOUND", "message": "Profile not found."})
 
     profile = {k: v for k, v in item.items() if k not in ("PK", "SK")}
     return _response(200, profile)
@@ -193,6 +201,32 @@ def handle_delete(caller_id: str, user_id: str) -> Dict[str, Any]:
 
     table.delete_item(Key={"PK": f"USER#{user_id}", "SK": "PROFILE"})
     return _response(200, {"message": "Profile deleted successfully"})
+
+def handle_user_banned(event: Dict[str, Any]) -> Dict[str, Any]:
+    detail = event.get("detail", {})
+    if isinstance(detail, str):
+        detail = json.loads(detail)
+
+    user_id = detail.get("userId")
+    if not user_id:
+        logger.warning("user.banned event missing userId")
+        return {"statusCode": 400, "body": "Missing userId"}
+
+    # 1. 标记 profile 为 banned
+    dynamodb.Table(PROFILES_TABLE_NAME).update_item(
+        Key={"PK": f"USER#{user_id}", "SK": "PROFILE"},
+        UpdateExpression="SET #status = :banned",
+        ExpressionAttributeNames={"#status": "status"},
+        ExpressionAttributeValues={":banned": "banned"},
+    )
+
+    # 2. 从 discovery 池里删掉这个用户
+    dynamodb.Table(DISCOVERY_TABLE_NAME).delete_item(
+        Key={"PK": f"PROFILE#{user_id}", "SK": "META"}
+    )
+
+    logger.info("User banned and removed from discovery: %s", user_id)
+    return {"statusCode": 200, "body": "User banned"}
 
 
 def _build_event_detail(item: Dict[str, Any]) -> Dict[str, Any]:

--- a/services/domain-1-identity/profile-service/tests/test_lambda_function.py
+++ b/services/domain-1-identity/profile-service/tests/test_lambda_function.py
@@ -392,6 +392,51 @@ class EventBridgeRoutingTests(unittest.TestCase):
             Key={"PK": "PROFILE#user-123", "SK": "META"}
         )
 
+    def test_user_banned_event_accepts_stringified_detail(self):
+        profile_table = MagicMock()
+        discovery_table = MagicMock()
+
+        def get_table(name):
+            if name == "kismet-profiles-dev":
+                return profile_table
+            if name == "kismet-discovery-dev":
+                return discovery_table
+            raise AssertionError(f"Unexpected table name: {name}")
+
+        event = {
+            "source": "kismet.report-service",
+            "detail-type": "user.banned",
+            "detail": json.dumps({"userId": "user-123"}),
+        }
+
+        with patch("lambda_function.PROFILES_TABLE_NAME", "kismet-profiles-dev"), \
+             patch("lambda_function.DISCOVERY_TABLE_NAME", "kismet-discovery-dev"), \
+             patch("lambda_function.dynamodb") as mock_dynamodb:
+            mock_dynamodb.Table.side_effect = get_table
+
+            response = handler(event, self.context)
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(response["body"], "User banned")
+        profile_table.update_item.assert_called_once()
+        discovery_table.delete_item.assert_called_once_with(
+            Key={"PK": "PROFILE#user-123", "SK": "META"}
+        )
+
+    def test_user_banned_event_missing_user_id_returns_400(self):
+        event = {
+            "source": "kismet.report-service",
+            "detail-type": "user.banned",
+            "detail": {},
+        }
+
+        with patch("lambda_function.dynamodb") as mock_dynamodb:
+            response = handler(event, self.context)
+
+        self.assertEqual(response["statusCode"], 400)
+        self.assertEqual(response["body"], "Missing userId")
+        mock_dynamodb.Table.assert_not_called()
+
     def test_user_banned_event_uses_shared_error_handling(self):
         event = {
             "source": "kismet.report-service",

--- a/services/domain-1-identity/profile-service/tests/test_lambda_function.py
+++ b/services/domain-1-identity/profile-service/tests/test_lambda_function.py
@@ -333,6 +333,25 @@ class RoutingTests(unittest.TestCase):
         self.assertEqual(payload["code"], "VALIDATION_ERROR")
 
 
+class EventBridgeRoutingTests(unittest.TestCase):
+    def setUp(self):
+        self.context = SimpleNamespace(aws_request_id="req-456")
+
+    def test_user_banned_event_uses_shared_error_handling(self):
+        event = {
+            "source": "kismet.report-service",
+            "detail-type": "user.banned",
+            "detail": {"userId": "user-123"},
+        }
+
+        with patch("lambda_function.handle_user_banned", side_effect=ValueError("boom")):
+            response = handler(event, self.context)
+            payload = json.loads(response["body"])
+
+        self.assertEqual(response["statusCode"], 500)
+        self.assertEqual(payload["code"], "INTERNAL_ERROR")
+
+
 def make_event(path, method, body=None, raw_body=None):
     payload = raw_body
     if payload is None and body is not None:

--- a/services/domain-1-identity/profile-service/tests/test_lambda_function.py
+++ b/services/domain-1-identity/profile-service/tests/test_lambda_function.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from lambda_function import handler
 
@@ -141,6 +141,24 @@ class GetProfileTests(unittest.TestCase):
             mock_dynamodb.Table.return_value.get_item.return_value = {}
 
             response = handler(make_event("/profiles/nonexistent", "GET"), self.context)
+            payload = json.loads(response["body"])
+
+            self.assertEqual(response["statusCode"], 404)
+            self.assertEqual(payload["code"], "NOT_FOUND")
+
+    def test_get_banned_profile_returns_404(self):
+        with patch.dict("os.environ", ENV), \
+             patch("lambda_function.dynamodb") as mock_dynamodb:
+
+            mock_dynamodb.Table.return_value.get_item.return_value = {"Item": {
+                "PK": "USER#user-123",
+                "SK": "PROFILE",
+                "userId": "user-123",
+                "name": "Alice",
+                "status": "banned",
+            }}
+
+            response = handler(make_event("/profiles/user-123", "GET"), self.context)
             payload = json.loads(response["body"])
 
             self.assertEqual(response["statusCode"], 404)
@@ -336,6 +354,43 @@ class RoutingTests(unittest.TestCase):
 class EventBridgeRoutingTests(unittest.TestCase):
     def setUp(self):
         self.context = SimpleNamespace(aws_request_id="req-456")
+
+    def test_user_banned_event_updates_profile_and_removes_from_discovery(self):
+        profile_table = MagicMock()
+        discovery_table = MagicMock()
+
+        def get_table(name):
+            if name == "kismet-profiles-dev":
+                return profile_table
+            if name == "kismet-discovery-dev":
+                return discovery_table
+            raise AssertionError(f"Unexpected table name: {name}")
+
+        event = {
+            "source": "kismet.report-service",
+            "detail-type": "user.banned",
+            "detail": {"userId": "user-123"},
+        }
+
+        with patch("lambda_function.PROFILES_TABLE_NAME", "kismet-profiles-dev"), \
+             patch("lambda_function.DISCOVERY_TABLE_NAME", "kismet-discovery-dev"), \
+             patch("lambda_function.dynamodb") as mock_dynamodb:
+            mock_dynamodb.Table.side_effect = get_table
+
+            response = handler(event, self.context)
+
+        self.assertEqual(response["statusCode"], 200)
+        self.assertEqual(response["body"], "User banned")
+        profile_table.update_item.assert_called_once_with(
+            Key={"PK": "USER#user-123", "SK": "PROFILE"},
+            UpdateExpression="SET #status = :banned",
+            ConditionExpression="attribute_exists(PK)",
+            ExpressionAttributeNames={"#status": "status"},
+            ExpressionAttributeValues={":banned": "banned"},
+        )
+        discovery_table.delete_item.assert_called_once_with(
+            Key={"PK": "PROFILE#user-123", "SK": "META"}
+        )
 
     def test_user_banned_event_uses_shared_error_handling(self):
         event = {


### PR DESCRIPTION
What changed

profile-service listens to user.banned EventBridge event from report-service
On ban: marks profile status: banned + deletes user from kismet-discovery table
GET /profiles/{userId} returns 404 for banned users
Removed email-verification-service from CDK stack (conflicts with Cognito auto_verify=True)
Fixed PHOTOS_CDN_BASE_URL — now uses S3 URL instead of empty string

CDK changes

profile-service: added DISCOVERY_TABLE_NAME env var + dynamodb:DeleteItem policy on kismet-discovery
photo-service: set PHOTOS_CDN_BASE_URL to s3.{region}.amazonaws.com