### PR TITLE
fix(infra): add CORS preflight for cross-stack API resources

### DIFF
--- a/infra/kismet_constructs/kismet_service.py
+++ b/infra/kismet_constructs/kismet_service.py
@@ -150,6 +150,7 @@ class KismetService(Construct):
         # ── API Gateway routes ────────────────────────────────────────────────
         if api and routes:
             integration = apigateway.LambdaIntegration(self.function)
+            cors_added: set[str] = set()
             for route in routes:
                 path_parts = [p for p in route["path"].split("/") if p]
                 resource = _get_or_create_resource(api.root, path_parts)
@@ -160,6 +161,18 @@ class KismetService(Construct):
                         apigateway.AuthorizationType.COGNITO
                     )
                 resource.add_method(route["method"], integration, **method_options)
+                # Add CORS OPTIONS method (needed for cross-stack imported APIs)
+                resource_path = resource.path
+                if resource_path not in cors_added:
+                    try:
+                        resource.add_cors_preflight(
+                            allow_origins=["*"],
+                            allow_methods=apigateway.Cors.ALL_METHODS,
+                            allow_headers=["Content-Type", "Authorization"],
+                        )
+                    except Exception:
+                        pass  # OPTIONS already exists on this resource
+                    cors_added.add(resource_path)
 
         # ── EventBridge: publish permission ──────────────────────────────────
         if publish_events and event_bus:


### PR DESCRIPTION
## Summary
- `default_cors_preflight_options` on `RestApi` does not propagate to resources created in domain stacks that import the API via `from_rest_api_attributes`
- Browser preflight (OPTIONS) requests return 403, blocking all frontend API calls from Vercel
- Fix: explicitly call `add_cors_preflight()` on each resource in `KismetService`

## Context
Frontend deployed to Vercel (https://frontend-hazel-two-58.vercel.app) — signup and all API calls fail with CORS error.

## Test plan
- [ ] `cdk synth` passes
- [ ] `cdk deploy` succeeds
- [ ] `curl -X OPTIONS` to any endpoint returns 200 with CORS headers
- [ ] Frontend signup works from Vercel domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)