### PR TITLE
fix(domain3): re-apply route fixes reverted by #89 merge

### DIFF
--- a/infra/stacks/domain3_stack.py
+++ b/infra/stacks/domain3_stack.py
@@ -70,7 +70,7 @@ class Domain3Stack(cdk.Stack):
             routes=[
                 {"method": "POST", "path": "/messages", "auth": True},
                 {"method": "POST", "path": "/messages/read", "auth": True},
-                {"method": "GET", "path": "/messages/{matchId}", "auth": True},
+                {"method": "GET", "path": "/messages/match/{matchId}", "auth": True},
                 {"method": "DELETE", "path": "/messages/{messageId}", "auth": True},
             ],
             consume_events=[],   # no incoming events; other services call via HTTP
@@ -232,7 +232,7 @@ class Domain3Stack(cdk.Stack):
             tables=[],  # created manually above to support TTL
             routes=[
                 {"method": "POST", "path": "/presence/heartbeat", "auth": True},
-                {"method": "GET",  "path": "/presence/{userId}",          "auth": True},
+                {"method": "GET",  "path": "/presence/user/{userId}",     "auth": True},
                 {"method": "POST", "path": "/presence/{matchId}/typing",  "auth": True},
                 {"method": "GET",  "path": "/presence/{matchId}/typing",  "auth": True},
             ],


### PR DESCRIPTION
## Problem
PR #89 was branched before PR #86 (route fix for #83) merged. When #89 merged, it reverted the path variable conflict fixes, re-introducing:
- `/messages/{matchId}` vs `/messages/{messageId}` conflict
- `/presence/{userId}` vs `/presence/{matchId}` conflict

This causes `cdk deploy KismetDomain3` to fail.

## Fix
Re-applies the same changes from #86:
- `/messages/{matchId}` → `/messages/match/{matchId}`
- `/presence/{userId}` → `/presence/user/{userId}`

Closes #83, closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)