### PR TITLE
style(domain-5): rebrand email templates and align push copy

### DIFF
--- a/services/domain-5-notifications/email-service/lambda_function.py
+++ b/services/domain-5-notifications/email-service/lambda_function.py
@@ -106,7 +106,7 @@ def on_user_created(detail):
     # Send welcome email
     send_ses_email(
         recipient=email,
-        subject="Welcome to Kismet!",
+        subject=get_subject_for_template("welcome"),
         body_text="Welcome to Kismet! We're excited to have you. Start by completing your profile to get discovered.",
         body_html=render_template("welcome", {"email": email}),
     )
@@ -132,7 +132,7 @@ def on_match_created(detail):
             continue
         send_ses_email(
             recipient=email,
-            subject="You have a new match on Kismet!",
+            subject=get_subject_for_template("match_notification"),
             body_text=f"Great news! You have a new match (ID: {match_id}). Open Kismet to start chatting!",
             body_html=render_template("match_notification", {"matchId": match_id, "userId": user_id}),
         )
@@ -149,7 +149,7 @@ def on_user_reported(detail):
 
     send_ses_email(
         recipient=ADMIN_EMAIL,
-        subject=f"[Kismet Admin] User Report: {reason}",
+        subject=get_subject_for_template("report_alert"),
         body_text=(
             f"Report ID: {report_id}\n"
             f"Reporter: {reporter_id}\n"
@@ -318,27 +318,96 @@ def render_template(template_name, data):
     a templating engine. For now, return simple HTML."""
     templates = {
         "welcome": (
-            "<h1>Welcome to Kismet!</h1>"
-            "<p>We're excited to have you. Complete your profile to start meeting people.</p>"
+            '<div style="background:#1a0e15;padding:48px 20px;font-family:Georgia,\'Times New Roman\',serif;">'
+            '<div style="max-width:560px;margin:0 auto;background:#2d1824;border:1px solid #3d2030;border-radius:8px;overflow:hidden;">'
+            '<div style="padding:56px 40px 36px;text-align:center;">'
+            '<div style="font-family:\'Allura\',\'Brush Script MT\',cursive;font-size:62px;color:#d9a74a;line-height:1;">Kismet</div>'
+            '<div style="margin:22px auto 0;padding-top:18px;border-top:1px solid #3d2030;max-width:320px;">'
+            '<div style="color:#b89b6e;font-size:14px;font-family:Georgia,serif;font-style:italic;">a meeting meant to happen</div>'
+            '</div></div>'
+            '<div style="padding:8px 48px 44px;color:#e8d9b8;font-size:16px;line-height:1.75;font-family:Georgia,serif;">'
+            '<p style="margin:0 0 20px;">Welcome.</p>'
+            '<p style="margin:0 0 20px;">We can\'t promise fate &mdash; but we can give it somewhere to show up.</p>'
+            '<p style="margin:0 0 36px;">Your profile is where it starts.</p>'
+            '<div style="text-align:center;margin:36px 0 8px;">'
+            '<a href="#" style="display:inline-block;background:#d9a74a;color:#1f1018;padding:15px 48px;border-radius:2px;text-decoration:none;font-family:Georgia,serif;font-size:13px;letter-spacing:3px;text-transform:uppercase;font-weight:bold;">Complete Profile</a>'
+            '</div></div>'
+            '<div style="padding:22px 40px;border-top:1px solid #3d2030;text-align:center;font-size:11px;color:#6e5538;line-height:1.7;font-family:Georgia,serif;">'
+            'You received this because you joined <span style="color:#a88959;">Kismet</span>.<br>'
+            '<a href="#" style="color:#8a6d45;text-decoration:underline;">Manage preferences</a>'
+            '</div></div></div>'
         ),
         "match_notification": (
-            "<h1>New Match!</h1>"
-            f"<p>You have a new match. Open Kismet to start chatting!</p>"
+            '<div style="background:#1a0e15;padding:48px 20px;font-family:Georgia,\'Times New Roman\',serif;">'
+            '<div style="max-width:560px;margin:0 auto;background:#2d1824;border:1px solid #3d2030;border-radius:8px;overflow:hidden;">'
+            '<div style="padding:44px 40px 28px;text-align:center;border-bottom:1px solid #3d2030;">'
+            '<div style="font-family:\'Allura\',\'Brush Script MT\',cursive;font-size:52px;color:#d9a74a;line-height:1;">Kismet</div>'
+            '</div>'
+            '<div style="padding:40px 48px;color:#e8d9b8;font-size:16px;line-height:1.75;font-family:Georgia,serif;">'
+            '<p style="margin:0 0 24px;font-size:20px;color:#d9a74a;font-style:italic;">The feeling is mutual.</p>'
+            '<p style="margin:0 0 36px;">Someone you liked liked you back. Whenever you\'re ready, the first word is yours.</p>'
+            '<div style="text-align:center;margin:36px 0 8px;">'
+            '<a href="#" style="display:inline-block;background:#d9a74a;color:#1f1018;padding:15px 48px;border-radius:2px;text-decoration:none;font-family:Georgia,serif;font-size:13px;letter-spacing:3px;text-transform:uppercase;font-weight:bold;">Start a conversation</a>'
+            '</div></div>'
+            '<div style="padding:22px 40px;border-top:1px solid #3d2030;text-align:center;font-size:11px;color:#6e5538;line-height:1.7;font-family:Georgia,serif;">'
+            'You\'re getting this because <span style="color:#a88959;">match notifications</span> are enabled.<br>'
+            '<a href="#" style="color:#8a6d45;text-decoration:underline;">Manage preferences</a>'
+            '</div></div></div>'
         ),
         "message_notification": (
-            "<h1>New Message</h1>"
-            "<p>You have a new message waiting for you on Kismet.</p>"
+            '<div style="background:#1a0e15;padding:48px 20px;font-family:Georgia,\'Times New Roman\',serif;">'
+            '<div style="max-width:560px;margin:0 auto;background:#2d1824;border:1px solid #3d2030;border-radius:8px;overflow:hidden;">'
+            '<div style="padding:44px 40px 28px;text-align:center;border-bottom:1px solid #3d2030;">'
+            '<div style="font-family:\'Allura\',\'Brush Script MT\',cursive;font-size:52px;color:#d9a74a;line-height:1;">Kismet</div>'
+            '</div>'
+            '<div style="padding:40px 48px;color:#e8d9b8;font-size:16px;line-height:1.75;font-family:Georgia,serif;">'
+            '<p style="margin:0 0 24px;font-size:20px;color:#d9a74a;font-style:italic;">A message is waiting.</p>'
+            '<p style="margin:0 0 36px;">Someone wrote to you on Kismet.</p>'
+            '<div style="text-align:center;margin:36px 0 8px;">'
+            '<a href="#" style="display:inline-block;background:#d9a74a;color:#1f1018;padding:15px 48px;border-radius:2px;text-decoration:none;font-family:Georgia,serif;font-size:13px;letter-spacing:3px;text-transform:uppercase;font-weight:bold;">Read message</a>'
+            '</div></div>'
+            '<div style="padding:22px 40px;border-top:1px solid #3d2030;text-align:center;font-size:11px;color:#6e5538;line-height:1.7;font-family:Georgia,serif;">'
+            'You\'re getting this because <span style="color:#a88959;">message notifications</span> are enabled.<br>'
+            '<a href="#" style="color:#8a6d45;text-decoration:underline;">Manage preferences</a>'
+            '</div></div></div>'
         ),
         "weekly_digest": (
-            "<h1>Your Weekly Kismet Digest</h1>"
-            "<p>Here's what happened this week on Kismet.</p>"
+            '<div style="background:#1a0e15;padding:48px 20px;font-family:Georgia,\'Times New Roman\',serif;">'
+            '<div style="max-width:560px;margin:0 auto;background:#2d1824;border:1px solid #3d2030;border-radius:8px;overflow:hidden;">'
+            '<div style="padding:44px 40px 28px;text-align:center;border-bottom:1px solid #3d2030;">'
+            '<div style="font-family:\'Allura\',\'Brush Script MT\',cursive;font-size:52px;color:#d9a74a;line-height:1;">Kismet</div>'
+            '</div>'
+            '<div style="padding:40px 48px;color:#e8d9b8;font-size:16px;line-height:1.75;font-family:Georgia,serif;">'
+            '<p style="margin:0 0 24px;font-size:20px;color:#d9a74a;font-style:italic;">This week on Kismet.</p>'
+            '<p style="margin:0 0 36px;">Matches made, messages exchanged, and conversations worth returning to.</p>'
+            '<div style="text-align:center;margin:36px 0 8px;">'
+            '<a href="#" style="display:inline-block;background:#d9a74a;color:#1f1018;padding:15px 48px;border-radius:2px;text-decoration:none;font-family:Georgia,serif;font-size:13px;letter-spacing:3px;text-transform:uppercase;font-weight:bold;">Return to Kismet</a>'
+            '</div></div>'
+            '<div style="padding:22px 40px;border-top:1px solid #3d2030;text-align:center;font-size:11px;color:#6e5538;line-height:1.7;font-family:Georgia,serif;">'
+            'You\'re getting this because the <span style="color:#a88959;">weekly digest</span> is enabled.<br>'
+            '<a href="#" style="color:#8a6d45;text-decoration:underline;">Manage preferences</a>'
+            '</div></div></div>'
         ),
         "report_alert": (
-            "<h1>User Report Alert</h1>"
-            f"<p>Report ID: {data.get('reportId', '')}</p>"
-            f"<p>Reporter: {data.get('reporterId', '')}</p>"
-            f"<p>Reported User: {data.get('reportedUserId', '')}</p>"
-            f"<p>Reason: {data.get('reason', '')}</p>"
+            '<div style="background:#e8d9b8;padding:48px 20px;font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',Roboto,sans-serif;">'
+            '<div style="max-width:560px;margin:0 auto;background:#f5ebd4;border:1px solid #d4c4a5;border-radius:2px;overflow:hidden;">'
+            '<div style="background:#2d1824;padding:14px 20px;">'
+            '<div style="color:#d9a74a;font-family:Georgia,serif;font-size:12px;letter-spacing:3px;text-transform:uppercase;">Kismet Admin</div>'
+            '</div>'
+            '<div style="padding:28px 24px;color:#22182a;font-size:13px;line-height:1.5;">'
+            '<div style="font-size:16px;font-weight:600;color:#22182a;letter-spacing:-0.2px;margin:0 0 4px;">User Report Submitted</div>'
+            '<div style="color:#6e5538;font-size:12px;margin:0 0 20px;">A user has been reported and awaits admin review.</div>'
+            '<div style="border-left:3px solid #2d1824;padding:12px 16px;background:#ede0c2;">'
+            '<table style="width:100%;border-collapse:collapse;">'
+            f'<tr><td style="padding:4px 0;color:#6e5538;font-size:11px;text-transform:uppercase;letter-spacing:1.5px;width:36%;">Report ID</td><td style="padding:4px 0;color:#22182a;font-family:\'SF Mono\',Menlo,Consolas,monospace;font-size:12px;">{data.get("reportId", "")}</td></tr>'
+            f'<tr><td style="padding:4px 0;color:#6e5538;font-size:11px;text-transform:uppercase;letter-spacing:1.5px;">Reporter</td><td style="padding:4px 0;color:#22182a;font-family:\'SF Mono\',Menlo,Consolas,monospace;font-size:12px;">{data.get("reporterId", "")}</td></tr>'
+            f'<tr><td style="padding:4px 0;color:#6e5538;font-size:11px;text-transform:uppercase;letter-spacing:1.5px;">Reported User</td><td style="padding:4px 0;color:#22182a;font-family:\'SF Mono\',Menlo,Consolas,monospace;font-size:12px;">{data.get("reportedUserId", "")}</td></tr>'
+            f'<tr><td style="padding:4px 0;color:#6e5538;font-size:11px;text-transform:uppercase;letter-spacing:1.5px;">Reason</td><td style="padding:4px 0;color:#22182a;font-size:12px;">{data.get("reason", "")}</td></tr>'
+            '</table>'
+            '</div>'
+            '<div style="margin-top:22px;">'
+            '<a href="#" style="display:inline-block;background:#2d1824;color:#f5ebd4;padding:10px 20px;border-radius:2px;text-decoration:none;font-size:11px;letter-spacing:1.5px;text-transform:uppercase;font-weight:600;">Review Report</a>'
+            '</div></div></div></div>'
         ),
     }
     return templates.get(template_name, "<p>Email content</p>")
@@ -346,11 +415,11 @@ def render_template(template_name, data):
 
 def get_subject_for_template(template_name):
     subjects = {
-        "welcome": "Welcome to Kismet!",
-        "match_notification": "You have a new match on Kismet!",
-        "message_notification": "You have a new message on Kismet",
-        "weekly_digest": "Your Weekly Kismet Digest",
-        "report_alert": "[Kismet Admin] User Report",
+        "welcome": "Welcome to Kismet",
+        "match_notification": "The feeling is mutual — a new match on Kismet",
+        "message_notification": "A message is waiting on Kismet",
+        "weekly_digest": "This week on Kismet",
+        "report_alert": "[Kismet Admin] New user report — action required",
     }
     return subjects.get(template_name, "Kismet Notification")
 

--- a/services/domain-5-notifications/push-notification-service/lambda_function.py
+++ b/services/domain-5-notifications/push-notification-service/lambda_function.py
@@ -77,8 +77,8 @@ def on_match_created(detail):
         notif = create_notification(
             user_id=user_id,
             notif_type="match",
-            title="You have a new match!",
-            body="You matched with someone new. Start a conversation!",
+            title="The feeling is mutual",
+            body="Someone you liked liked you back.",
             timestamp=timestamp,
             reference_id=match_id,
         )
@@ -102,7 +102,7 @@ def on_message_sent(detail):
     notif = create_notification(
         user_id=recipient_id,
         notif_type="message",
-        title="New message",
+        title="A message is waiting",
         body=preview,
         timestamp=timestamp,
         reference_id=match_id,


### PR DESCRIPTION
Redesign all five email templates with Kismet's plum/gold palette and refreshed copy. Align match and message push notification strings with the email tone.

## Files changed
- `services/domain-5-notifications/email-service/lambda_function.py` — templates + subjects + handler subject fixes
- `services/domain-5-notifications/push-notification-service/lambda_function.py` — push copy alignment