### PR TITLE
fix photo filter issue

### DIFF
--- a/frontend/src/hooks/usePhotos.ts
+++ b/frontend/src/hooks/usePhotos.ts
@@ -38,14 +38,12 @@ export function usePhotos(userId?: string) {
     async (file: File) => {
       setUploading(true);
       try {
-        // 1. Get presigned URL
         const { uploadUrl, photoId } = await api.post<PhotoUploadResponse>(
           "/photos/upload",
           { contentType: file.type, filename: file.name }
         );
-        // 2. Upload directly to S3
         await uploadToS3(uploadUrl, file);
-        // 3. Refresh photos list
+        await api.post(`/photos/${photoId}/confirm`);
         await fetchPhotos();
         return photoId;
       } finally {

--- a/infra/stacks/domain1_stack.py
+++ b/infra/stacks/domain1_stack.py
@@ -118,6 +118,7 @@ class Domain1Stack(cdk.Stack):
             ],
             routes=[
                 {"method": "POST", "path": "/photos/upload", "auth": True},
+                {"method": "POST", "path": "/photos/{photoId}/confirm", "auth": True},
                 {"method": "GET", "path": "/users/{userId}/photos", "auth": True},
                 {"method": "DELETE", "path": "/photos/{photoId}", "auth": True},
                 {"method": "PUT", "path": "/photos/{photoId}/primary", "auth": True},

--- a/infra/stacks/domain4_stack.py
+++ b/infra/stacks/domain4_stack.py
@@ -29,7 +29,7 @@ class Domain4Stack(cdk.Stack):
 
         text_moderation_table = "kismet-text-moderation-dev"
         image_moderation_table = "kismet-image-moderation-dev"
-        photos_table_name = "kismet-photos-dev"
+        photos_table_name = "kismet-photos"
 
         imported_api = apigateway.RestApi.from_rest_api_attributes(
             self,

--- a/services/domain-1-identity/photo-service/lambda_function.py
+++ b/services/domain-1-identity/photo-service/lambda_function.py
@@ -177,7 +177,7 @@ def handle_list(user_id: str) -> Dict[str, Any]:
     photos = []
     for item in result.get("Items", []):
         status = item.get("status", "active")
-        if status == "rejected":
+        if status in ("rejected", "pending"):
             continue
         photos.append({
             "photoId": item["photoId"],

--- a/services/domain-1-identity/photo-service/lambda_function.py
+++ b/services/domain-1-identity/photo-service/lambda_function.py
@@ -17,6 +17,7 @@ SERVICE_NAME = "photo-service"
 USER_PHOTOS_PATTERN = re.compile(r"^/users/(?P<userId>[^/]+)/photos$")
 PHOTO_DETAIL_PATTERN = re.compile(r"^/photos/(?P<photoId>[^/]+)$")
 PHOTO_PRIMARY_PATTERN = re.compile(r"^/photos/(?P<photoId>[^/]+)/primary$")
+PHOTO_CONFIRM_PATTERN = re.compile(r"^/photos/(?P<photoId>[^/]+)/confirm$")
 
 PHOTOS_TABLE_NAME = os.environ.get("PHOTOS_TABLE_NAME", "")
 PHOTOS_BUCKET_NAME = os.environ.get("PHOTOS_BUCKET_NAME", "")
@@ -41,6 +42,7 @@ def handler(event, context):
     operation = None
     user_photos_match = USER_PHOTOS_PATTERN.match(path)
     primary_match = PHOTO_PRIMARY_PATTERN.match(path)
+    confirm_match = PHOTO_CONFIRM_PATTERN.match(path)
     detail_match = PHOTO_DETAIL_PATTERN.match(path)
 
     try:
@@ -54,6 +56,11 @@ def handler(event, context):
             if not user_id:
                 return _response(401, {"code": "UNAUTHORIZED", "message": "Authentication required."})
             return handle_upload(user_id, payload or {})
+        elif confirm_match and method == "POST":
+            operation = "confirmPhoto"
+            if not user_id:
+                return _response(401, {"code": "UNAUTHORIZED", "message": "Authentication required."})
+            return handle_confirm(user_id, confirm_match.group("photoId"))
         elif primary_match and method == "PUT":
             operation = "setPrimaryPhoto"
             if not user_id:
@@ -96,7 +103,7 @@ def handle_upload(user_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
     ext = "jpg" if content_type == "image/jpeg" else content_type.split("/")[-1]
     s3_key = f"{user_id}/{photo_id}.{ext}"
     uploaded_at = datetime.now(timezone.utc).isoformat()
-    is_primary = existing.get("Count", 0) == 0  # first photo is primary by default
+    is_primary = existing.get("Count", 0) == 0
 
     upload_url = s3.generate_presigned_url(
         "put_object",
@@ -113,8 +120,32 @@ def handle_upload(user_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
         "contentType": content_type,
         "filename": filename,
         "isPrimary": is_primary,
+        "status": "pending",
         "uploadedAt": uploaded_at,
     })
+
+    return _response(200, {"photoId": photo_id, "uploadUrl": upload_url, "expiresIn": PRESIGNED_URL_EXPIRY})
+
+
+def handle_confirm(user_id: str, photo_id: str) -> Dict[str, Any]:
+    table = dynamodb.Table(PHOTOS_TABLE_NAME)
+    result = table.get_item(Key={"PK": f"USER#{user_id}", "SK": f"PHOTO#{photo_id}"})
+    item = result.get("Item")
+
+    if not item:
+        return _response(404, {"code": "NOT_FOUND", "message": "Photo not found."})
+    if item.get("status") != "pending":
+        return _response(409, {"code": "CONFLICT", "message": "Photo already confirmed."})
+
+    table.update_item(
+        Key={"PK": f"USER#{user_id}", "SK": f"PHOTO#{photo_id}"},
+        UpdateExpression="SET #st = :active",
+        ExpressionAttributeNames={"#st": "status"},
+        ExpressionAttributeValues={":active": "active"},
+    )
+
+    s3_key = item["s3Key"]
+    is_primary = item.get("isPrimary", False)
 
     events.put_events(Entries=[{
         "Source": "kismet.photo-service",
@@ -124,20 +155,19 @@ def handle_upload(user_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
             "userId": user_id,
             "s3Key": s3_key,
             "s3Bucket": PHOTOS_BUCKET_NAME,
-            "contentType": content_type,
+            "contentType": item.get("contentType", ""),
             "cdnUrl": f"{PHOTOS_CDN_BASE_URL}/{s3_key}" if PHOTOS_CDN_BASE_URL else "",
             "isPrimary": is_primary,
-            "timestamp": uploaded_at,
+            "timestamp": item.get("uploadedAt", ""),
         }),
         "EventBusName": EVENT_BUS_NAME,
     }])
 
-    # Auto-update profile avatarUrl if this is the primary photo
     if is_primary:
         cdn_url = f"{PHOTOS_CDN_BASE_URL}/{s3_key}" if PHOTOS_CDN_BASE_URL else ""
         _update_profile_avatar(user_id, cdn_url)
 
-    return _response(200, {"photoId": photo_id, "uploadUrl": upload_url, "expiresIn": PRESIGNED_URL_EXPIRY})
+    return _response(200, {"photoId": photo_id, "status": "active"})
 
 
 def handle_list(user_id: str) -> Dict[str, Any]:
@@ -146,6 +176,9 @@ def handle_list(user_id: str) -> Dict[str, Any]:
 
     photos = []
     for item in result.get("Items", []):
+        status = item.get("status", "active")
+        if status == "rejected":
+            continue
         photos.append({
             "photoId": item["photoId"],
             "url": f"{PHOTOS_CDN_BASE_URL}/{item['s3Key']}",

--- a/services/domain-1-identity/photo-service/tests/test_lambda_function.py
+++ b/services/domain-1-identity/photo-service/tests/test_lambda_function.py
@@ -144,7 +144,7 @@ class ListPhotosTests(unittest.TestCase):
             self.assertEqual(payload["count"], 0)
             self.assertEqual(payload["photos"], [])
 
-    def test_list_filters_out_rejected_photos(self):
+    def test_list_filters_out_rejected_and_pending_photos(self):
         with patch.dict("os.environ", ENV), \
              patch("lambda_function.PHOTOS_CDN_BASE_URL", ENV["PHOTOS_CDN_BASE_URL"]), \
              patch("lambda_function.dynamodb") as mock_dynamodb:
@@ -152,7 +152,8 @@ class ListPhotosTests(unittest.TestCase):
             mock_dynamodb.Table.return_value.query.return_value = {"Items": [
                 {"photoId": "photo-001", "s3Key": "user-123/photo-001.jpg", "isPrimary": True, "status": "active", "uploadedAt": "2026-04-01T12:00:00+00:00"},
                 {"photoId": "photo-002", "s3Key": "user-123/photo-002.jpg", "isPrimary": False, "status": "rejected", "uploadedAt": "2026-04-01T11:00:00+00:00"},
-                {"photoId": "photo-003", "s3Key": "user-123/photo-003.jpg", "isPrimary": False, "status": "active", "uploadedAt": "2026-04-01T10:00:00+00:00"},
+                {"photoId": "photo-003", "s3Key": "user-123/photo-003.jpg", "isPrimary": False, "status": "pending", "uploadedAt": "2026-04-01T10:30:00+00:00"},
+                {"photoId": "photo-004", "s3Key": "user-123/photo-004.jpg", "isPrimary": False, "status": "active", "uploadedAt": "2026-04-01T10:00:00+00:00"},
             ]}
 
             response = handler(make_event("/users/user-123/photos", "GET"), self.context)
@@ -163,7 +164,8 @@ class ListPhotosTests(unittest.TestCase):
             photo_ids = [p["photoId"] for p in payload["photos"]]
             self.assertIn("photo-001", photo_ids)
             self.assertNotIn("photo-002", photo_ids)
-            self.assertIn("photo-003", photo_ids)
+            self.assertNotIn("photo-003", photo_ids)
+            self.assertIn("photo-004", photo_ids)
 
     def test_get_route_extracts_user_id(self):
         with patch.dict("os.environ", ENV), \

--- a/services/domain-1-identity/photo-service/tests/test_lambda_function.py
+++ b/services/domain-1-identity/photo-service/tests/test_lambda_function.py
@@ -27,14 +27,12 @@ class UploadPhotoTests(unittest.TestCase):
     def test_upload_success(self):
         with patch.dict("os.environ", ENV), \
              patch("lambda_function.dynamodb") as mock_dynamodb, \
-             patch("lambda_function.s3") as mock_s3, \
-             patch("lambda_function.events") as mock_events:
+             patch("lambda_function.s3") as mock_s3:
 
             mock_table = mock_dynamodb.Table.return_value
             mock_table.query.return_value = {"Count": 0, "Items": []}
             mock_table.put_item.return_value = {}
             mock_s3.generate_presigned_url.return_value = "https://s3.example.com/presigned"
-            mock_events.put_events.return_value = {"FailedEntryCount": 0, "Entries": [{"EventId": "e1"}]}
 
             event = {**make_event("/photos/upload", "POST", body={"contentType": "image/jpeg", "filename": "profile.jpg"}), **AUTHED_EVENT_CONTEXT}
             response = handler(event, self.context)
@@ -44,6 +42,39 @@ class UploadPhotoTests(unittest.TestCase):
             self.assertIn("photoId", payload)
             self.assertEqual(payload["uploadUrl"], "https://s3.example.com/presigned")
             self.assertEqual(payload["expiresIn"], 300)
+
+    def test_upload_writes_pending_status(self):
+        with patch.dict("os.environ", ENV), \
+             patch("lambda_function.dynamodb") as mock_dynamodb, \
+             patch("lambda_function.s3") as mock_s3:
+
+            mock_table = mock_dynamodb.Table.return_value
+            mock_table.query.return_value = {"Count": 0, "Items": []}
+            mock_table.put_item.return_value = {}
+            mock_s3.generate_presigned_url.return_value = "https://s3.example.com/presigned"
+
+            event = {**make_event("/photos/upload", "POST", body={"contentType": "image/jpeg"}), **AUTHED_EVENT_CONTEXT}
+            handler(event, self.context)
+
+            put_call = mock_table.put_item.call_args
+            item = put_call[1]["Item"]
+            self.assertEqual(item["status"], "pending")
+
+    def test_upload_does_not_fire_event(self):
+        with patch.dict("os.environ", ENV), \
+             patch("lambda_function.dynamodb") as mock_dynamodb, \
+             patch("lambda_function.s3") as mock_s3, \
+             patch("lambda_function.events") as mock_events:
+
+            mock_table = mock_dynamodb.Table.return_value
+            mock_table.query.return_value = {"Count": 0, "Items": []}
+            mock_table.put_item.return_value = {}
+            mock_s3.generate_presigned_url.return_value = "https://s3.example.com/presigned"
+
+            event = {**make_event("/photos/upload", "POST", body={"contentType": "image/jpeg"}), **AUTHED_EVENT_CONTEXT}
+            handler(event, self.context)
+
+            mock_events.put_events.assert_not_called()
 
     def test_upload_unauthenticated_returns_401(self):
         with patch.dict("os.environ", ENV):
@@ -112,6 +143,27 @@ class ListPhotosTests(unittest.TestCase):
             self.assertEqual(response["statusCode"], 200)
             self.assertEqual(payload["count"], 0)
             self.assertEqual(payload["photos"], [])
+
+    def test_list_filters_out_rejected_photos(self):
+        with patch.dict("os.environ", ENV), \
+             patch("lambda_function.PHOTOS_CDN_BASE_URL", ENV["PHOTOS_CDN_BASE_URL"]), \
+             patch("lambda_function.dynamodb") as mock_dynamodb:
+
+            mock_dynamodb.Table.return_value.query.return_value = {"Items": [
+                {"photoId": "photo-001", "s3Key": "user-123/photo-001.jpg", "isPrimary": True, "status": "active", "uploadedAt": "2026-04-01T12:00:00+00:00"},
+                {"photoId": "photo-002", "s3Key": "user-123/photo-002.jpg", "isPrimary": False, "status": "rejected", "uploadedAt": "2026-04-01T11:00:00+00:00"},
+                {"photoId": "photo-003", "s3Key": "user-123/photo-003.jpg", "isPrimary": False, "status": "active", "uploadedAt": "2026-04-01T10:00:00+00:00"},
+            ]}
+
+            response = handler(make_event("/users/user-123/photos", "GET"), self.context)
+            payload = json.loads(response["body"])
+
+            self.assertEqual(response["statusCode"], 200)
+            self.assertEqual(payload["count"], 2)
+            photo_ids = [p["photoId"] for p in payload["photos"]]
+            self.assertIn("photo-001", photo_ids)
+            self.assertNotIn("photo-002", photo_ids)
+            self.assertIn("photo-003", photo_ids)
 
     def test_get_route_extracts_user_id(self):
         with patch.dict("os.environ", ENV), \
@@ -237,24 +289,50 @@ class CorsTests(unittest.TestCase):
             self.assertIn("Authorization", response["headers"]["Access-Control-Allow-Headers"])
 
 
-class PhotoEventTests(unittest.TestCase):
+class ConfirmPhotoTests(unittest.TestCase):
     def setUp(self):
         self.context = SimpleNamespace(aws_request_id="req-photo-456")
 
-    def test_upload_event_includes_cdn_url(self):
+    def _pending_item(self, photo_id="photo-001"):
+        return {
+            "PK": "USER#user-123", "SK": f"PHOTO#{photo_id}",
+            "photoId": photo_id, "userId": "user-123",
+            "s3Key": f"user-123/{photo_id}.jpg", "contentType": "image/jpeg",
+            "isPrimary": True, "status": "pending",
+            "uploadedAt": "2026-04-01T12:00:00+00:00",
+        }
+
+    def test_confirm_success(self):
         with patch.dict("os.environ", ENV), \
              patch("lambda_function.PHOTOS_CDN_BASE_URL", "https://photos.kismet.dev"), \
              patch("lambda_function.dynamodb") as mock_dynamodb, \
-             patch("lambda_function.s3") as mock_s3, \
              patch("lambda_function.events") as mock_events:
 
             mock_table = mock_dynamodb.Table.return_value
-            mock_table.query.return_value = {"Count": 0, "Items": []}
-            mock_table.put_item.return_value = {}
-            mock_s3.generate_presigned_url.return_value = "https://s3.example.com/presigned"
+            mock_table.get_item.return_value = {"Item": self._pending_item()}
+            mock_table.update_item.return_value = {}
             mock_events.put_events.return_value = {"FailedEntryCount": 0, "Entries": [{"EventId": "e1"}]}
 
-            event = {**make_event("/photos/upload", "POST", body={"contentType": "image/jpeg"}), **AUTHED_EVENT_CONTEXT}
+            event = {**make_event("/photos/photo-001/confirm", "POST"), **AUTHED_EVENT_CONTEXT}
+            response = handler(event, self.context)
+            payload = json.loads(response["body"])
+
+            self.assertEqual(response["statusCode"], 200)
+            self.assertEqual(payload["photoId"], "photo-001")
+            self.assertEqual(payload["status"], "active")
+
+    def test_confirm_fires_event_with_cdn_url(self):
+        with patch.dict("os.environ", ENV), \
+             patch("lambda_function.PHOTOS_CDN_BASE_URL", "https://photos.kismet.dev"), \
+             patch("lambda_function.dynamodb") as mock_dynamodb, \
+             patch("lambda_function.events") as mock_events:
+
+            mock_table = mock_dynamodb.Table.return_value
+            mock_table.get_item.return_value = {"Item": self._pending_item()}
+            mock_table.update_item.return_value = {}
+            mock_events.put_events.return_value = {"FailedEntryCount": 0, "Entries": [{"EventId": "e1"}]}
+
+            event = {**make_event("/photos/photo-001/confirm", "POST"), **AUTHED_EVENT_CONTEXT}
             handler(event, self.context)
 
             call_args = mock_events.put_events.call_args
@@ -262,6 +340,37 @@ class PhotoEventTests(unittest.TestCase):
             self.assertIn("cdnUrl", detail)
             self.assertTrue(detail["cdnUrl"].startswith("https://photos.kismet.dev/"))
             self.assertIn("isPrimary", detail)
+
+    def test_confirm_not_found_returns_404(self):
+        with patch.dict("os.environ", ENV), \
+             patch("lambda_function.dynamodb") as mock_dynamodb:
+
+            mock_dynamodb.Table.return_value.get_item.return_value = {}
+
+            event = {**make_event("/photos/nonexistent/confirm", "POST"), **AUTHED_EVENT_CONTEXT}
+            response = handler(event, self.context)
+
+            self.assertEqual(response["statusCode"], 404)
+
+    def test_confirm_already_active_returns_409(self):
+        with patch.dict("os.environ", ENV), \
+             patch("lambda_function.dynamodb") as mock_dynamodb:
+
+            item = self._pending_item()
+            item["status"] = "active"
+            mock_dynamodb.Table.return_value.get_item.return_value = {"Item": item}
+
+            event = {**make_event("/photos/photo-001/confirm", "POST"), **AUTHED_EVENT_CONTEXT}
+            response = handler(event, self.context)
+            payload = json.loads(response["body"])
+
+            self.assertEqual(response["statusCode"], 409)
+            self.assertEqual(payload["code"], "CONFLICT")
+
+    def test_confirm_unauthenticated_returns_401(self):
+        with patch.dict("os.environ", ENV):
+            response = handler(make_event("/photos/photo-001/confirm", "POST"), self.context)
+            self.assertEqual(response["statusCode"], 401)
 
 
 class RoutingTests(unittest.TestCase):


### PR DESCRIPTION
Fix: Photo Filtering

**Race condition:** Moved photo.uploaded EventBridge event from handle_upload to a new POST /photos/{photoId}/confirm endpoint, so Domain-4 only scans after the file is in S3.
**Table name mismatch:** Changed Domain-4's PHOTOS_TABLE_NAME from kismet-photos-dev to kismet-photos to match Domain-1.
**No filtering:** Added status == "rejected" filter in Domain-1's handle_list so rejected photos are no longer returned to the frontend.
**Upload status tracking:** New photos are written with status: "pending", changed to "active" on confirm.
**Frontend confirm step:** usePhotos.uploadPhoto now calls /photos/{photoId}/confirm after S3 upload before refreshing the list.