### PR TITLE
fix(photos): normalize uploads to JPEG for Rekognition

### DIFF
--- a/frontend/src/hooks/usePhotos.ts
+++ b/frontend/src/hooks/usePhotos.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { api, uploadToS3 } from "@/lib/api";
 import { getUserIdFromToken } from "@/lib/auth";
+import { normalizeImageFile } from "@/lib/imageUtils";
 import type { Photo, PhotoUploadResponse } from "@/types";
 
 export function usePhotos(userId?: string) {
@@ -38,11 +39,14 @@ export function usePhotos(userId?: string) {
     async (file: File) => {
       setUploading(true);
       try {
+        // Rekognition only accepts JPEG/PNG — convert WebP/HEIC/etc. so
+        // D4 image-moderation can actually scan the upload.
+        const normalized = await normalizeImageFile(file);
         const { uploadUrl, photoId } = await api.post<PhotoUploadResponse>(
           "/photos/upload",
-          { contentType: file.type, filename: file.name }
+          { contentType: normalized.type, filename: normalized.name }
         );
-        await uploadToS3(uploadUrl, file);
+        await uploadToS3(uploadUrl, normalized);
         await api.post(`/photos/${photoId}/confirm`);
         await fetchPhotos();
         return photoId;

--- a/frontend/src/lib/imageUtils.ts
+++ b/frontend/src/lib/imageUtils.ts
@@ -1,0 +1,52 @@
+/**
+ * Convert any image File to a Rekognition-compatible JPEG.
+ *
+ * AWS Rekognition (used by the moderation pipeline) only accepts PNG and JPEG.
+ * Chrome's "Save image as…" and many iPhone/Android sources produce WebP / HEIC,
+ * which would otherwise be silently skipped by moderation. Normalizing here
+ * guarantees every upload is scannable.
+ *
+ * PNG files pass through unchanged; JPEG files pass through unchanged.
+ * Everything else is re-encoded to JPEG at 0.92 quality via <canvas>.
+ */
+export async function normalizeImageFile(file: File): Promise<File> {
+  const isJpeg = file.type === "image/jpeg" || file.type === "image/jpg";
+  const isPng = file.type === "image/png";
+  if (isJpeg || isPng) return file;
+
+  const dataUrl = await readAsDataUrl(file);
+  const img = await loadImage(dataUrl);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas 2D context unavailable");
+  ctx.drawImage(img, 0, 0);
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/jpeg", 0.92),
+  );
+  if (!blob) throw new Error("Failed to encode image as JPEG");
+
+  const newName = file.name.replace(/\.[^.]+$/, "") + ".jpg";
+  return new File([blob], newName, { type: "image/jpeg" });
+}
+
+function readAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error("FileReader failed"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("Image decode failed"));
+    img.src = src;
+  });
+}


### PR DESCRIPTION
## Summary

- AWS Rekognition (D4 image-moderation) only accepts JPEG/PNG
- Chrome's "Save image as…" defaults to WebP; iPhones hand out HEIC → image-moderation threw \`InvalidImageFormatException\` and silently skipped the scan (confirmed in CloudWatch today with a WebP gun photo that never got flagged)
- New \`normalizeImageFile\` helper runs before every upload:
  - JPEG / PNG pass through unchanged
  - Anything else → re-encoded to JPEG (0.92 quality) via \`<canvas>\`
  - Filename extension rewritten to \`.jpg\` so S3/CloudFront serve correct Content-Type

Paired with #115 (handler fix) — with both merged, the D4 moderation pipeline finally scans every upload end-to-end.

## Test plan

- [ ] Upload a \`.jpg\` photo → uploads unchanged, moderation scan runs
- [ ] Upload a \`.png\` photo → uploads unchanged
- [ ] Upload a \`.webp\` photo (right-click-save from Chrome) → gets converted to JPEG client-side, Rekognition scans successfully
- [ ] Upload an inappropriate image → \`kismet-photos\` row transitions to \`status: rejected\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)