### PR TITLE
feat(photos): show rejection dialog when moderation flags a photo

### DIFF
--- a/frontend/src/app/(main)/onboarding/photos/page.tsx
+++ b/frontend/src/app/(main)/onboarding/photos/page.tsx
@@ -1,14 +1,17 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { usePhotos } from "@/hooks/usePhotos";
 import { PhotoUploader } from "@/components/profile/PhotoUploader";
+import { PhotoRejectedDialog } from "@/components/profile/PhotoRejectedDialog";
 import { Button } from "@/components/ui/button";
 import { Camera } from "@phosphor-icons/react";
 
 export default function OnboardingPhotosPage() {
   const router = useRouter();
   const { photos, uploading, uploadPhoto, deletePhoto, setPrimary } = usePhotos();
+  const [rejectedOpen, setRejectedOpen] = useState(false);
 
   const canContinue = photos.length >= 1;
 
@@ -28,11 +31,16 @@ export default function OnboardingPhotosPage() {
         <PhotoUploader
           photos={photos}
           uploading={uploading}
-          onUpload={async (file) => { await uploadPhoto(file); }}
+          onUpload={async (file) => {
+            const { rejected } = await uploadPhoto(file);
+            if (rejected) setRejectedOpen(true);
+          }}
           onDelete={async (id) => { await deletePhoto(id); }}
           onSetPrimary={async (id) => { await setPrimary(id); }}
         />
       </div>
+
+      <PhotoRejectedDialog open={rejectedOpen} onClose={() => setRejectedOpen(false)} />
 
       <div className="mt-6 space-y-3">
         <Button

--- a/frontend/src/app/(main)/profile/edit/page.tsx
+++ b/frontend/src/app/(main)/profile/edit/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useProfile } from "@/hooks/useProfile";
 import { usePhotos } from "@/hooks/usePhotos";
 import { ProfileForm } from "@/components/profile/ProfileForm";
 import { PhotoUploader } from "@/components/profile/PhotoUploader";
+import { PhotoRejectedDialog } from "@/components/profile/PhotoRejectedDialog";
 import { LoadingSpinner } from "@/components/shared/LoadingSpinner";
 import { ArrowLeft } from "@phosphor-icons/react";
 
@@ -12,6 +14,7 @@ export default function ProfileEditPage() {
   const router = useRouter();
   const { profile, loading, updateProfile } = useProfile();
   const { photos, uploading, uploadPhoto, deletePhoto, setPrimary } = usePhotos();
+  const [rejectedOpen, setRejectedOpen] = useState(false);
 
   if (loading) return <LoadingSpinner size={48} className="flex-1 py-20" />;
 
@@ -33,11 +36,16 @@ export default function ProfileEditPage() {
         <PhotoUploader
           photos={photos}
           uploading={uploading}
-          onUpload={async (file) => { await uploadPhoto(file); }}
+          onUpload={async (file) => {
+            const { rejected } = await uploadPhoto(file);
+            if (rejected) setRejectedOpen(true);
+          }}
           onDelete={async (id) => { await deletePhoto(id); }}
           onSetPrimary={async (id) => { await setPrimary(id); }}
         />
       </div>
+
+      <PhotoRejectedDialog open={rejectedOpen} onClose={() => setRejectedOpen(false)} />
 
       {/* Profile form */}
       <ProfileForm

--- a/frontend/src/components/profile/PhotoRejectedDialog.tsx
+++ b/frontend/src/components/profile/PhotoRejectedDialog.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { ShieldWarning } from "@phosphor-icons/react";
+
+interface PhotoRejectedDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Shown when an uploaded photo is rejected by the D4 moderation pipeline
+ * (AWS Rekognition flagged nudity, violence, weapons, etc). We can't surface
+ * the exact reason to users without inviting gaming, so we keep it generic.
+ */
+export function PhotoRejectedDialog({ open, onClose }: PhotoRejectedDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-destructive/10">
+            <ShieldWarning size={24} className="text-destructive" weight="fill" />
+          </div>
+          <DialogTitle className="text-center">Photo couldn&apos;t be uploaded</DialogTitle>
+          <DialogDescription className="text-center">
+            Our content review flagged this image as inappropriate. Please pick a different photo —
+            a clear selfie works best.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button onClick={onClose} className="w-full">
+            Got it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/hooks/usePhotos.ts
+++ b/frontend/src/hooks/usePhotos.ts
@@ -36,7 +36,7 @@ export function usePhotos(userId?: string) {
   }, [fetchPhotos]);
 
   const uploadPhoto = useCallback(
-    async (file: File) => {
+    async (file: File): Promise<{ photoId: string; rejected: boolean }> => {
       setUploading(true);
       try {
         // Rekognition only accepts JPEG/PNG — convert WebP/HEIC/etc. so
@@ -48,13 +48,32 @@ export function usePhotos(userId?: string) {
         );
         await uploadToS3(uploadUrl, normalized);
         await api.post(`/photos/${photoId}/confirm`);
-        await fetchPhotos();
-        return photoId;
+
+        // D4 moderation is async (Rekognition typically ~1-3s). Wait long
+        // enough for the scan to settle, then check whether the photo is
+        // still in the list — the backend filters out rejected photos so
+        // missing == flagged.
+        await new Promise((r) => setTimeout(r, 5000));
+        let rejected = true;
+        if (targetId) {
+          try {
+            const data = await api.get<{ photos: Photo[]; count: number }>(
+              `/users/${targetId}/photos`
+            );
+            setPhotos(data.photos);
+            rejected = !data.photos.some((p) => p.photoId === photoId);
+          } catch {
+            // network failure — assume not rejected rather than lie to user
+            rejected = false;
+          }
+        }
+
+        return { photoId, rejected };
       } finally {
         setUploading(false);
       }
     },
-    [fetchPhotos]
+    [targetId]
   );
 
   const deletePhoto = useCallback(

--- a/frontend/src/hooks/usePhotos.ts
+++ b/frontend/src/hooks/usePhotos.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { api, uploadToS3 } from "@/lib/api";
 import { getUserIdFromToken } from "@/lib/auth";
+import { normalizeImageFile } from "@/lib/imageUtils";
 import type { Photo, PhotoUploadResponse } from "@/types";
 
 export function usePhotos(userId?: string) {
@@ -38,11 +39,14 @@ export function usePhotos(userId?: string) {
     async (file: File) => {
       setUploading(true);
       try {
+        // Rekognition only accepts JPEG/PNG — convert WebP/HEIC/etc. so
+        // D4 image-moderation can actually scan the upload.
+        const normalized = await normalizeImageFile(file);
         const { uploadUrl, photoId } = await api.post<PhotoUploadResponse>(
           "/photos/upload",
-          { contentType: file.type, filename: file.name }
+          { contentType: normalized.type, filename: normalized.name }
         );
-        await uploadToS3(uploadUrl, file);
+        await uploadToS3(uploadUrl, normalized);
         await api.post(`/photos/${photoId}/confirm`);
         await fetchPhotos();
         return photoId;

--- a/frontend/src/lib/imageUtils.ts
+++ b/frontend/src/lib/imageUtils.ts
@@ -1,0 +1,52 @@
+/**
+ * Convert any image File to a Rekognition-compatible JPEG.
+ *
+ * AWS Rekognition (used by the moderation pipeline) only accepts PNG and JPEG.
+ * Chrome's "Save image as…" and many iPhone/Android sources produce WebP / HEIC,
+ * which would otherwise be silently skipped by moderation. Normalizing here
+ * guarantees every upload is scannable.
+ *
+ * PNG files pass through unchanged; JPEG files pass through unchanged.
+ * Everything else is re-encoded to JPEG at 0.92 quality via <canvas>.
+ */
+export async function normalizeImageFile(file: File): Promise<File> {
+  const isJpeg = file.type === "image/jpeg" || file.type === "image/jpg";
+  const isPng = file.type === "image/png";
+  if (isJpeg || isPng) return file;
+
+  const dataUrl = await readAsDataUrl(file);
+  const img = await loadImage(dataUrl);
+
+  const canvas = document.createElement("canvas");
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas 2D context unavailable");
+  ctx.drawImage(img, 0, 0);
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/jpeg", 0.92),
+  );
+  if (!blob) throw new Error("Failed to encode image as JPEG");
+
+  const newName = file.name.replace(/\.[^.]+$/, "") + ".jpg";
+  return new File([blob], newName, { type: "image/jpeg" });
+}
+
+function readAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error("FileReader failed"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error("Image decode failed"));
+    img.src = src;
+  });
+}


### PR DESCRIPTION
## Summary

- Before: if D4 image-moderation flagged an upload (weapons, nudity, etc.), the photo just vanished from the user's list with zero feedback
- Now: \`uploadPhoto\` waits ~5s for async moderation, re-checks the list, and returns \`{ photoId, rejected }\`
- New \`PhotoRejectedDialog\` surfaces a friendly, generic message ("Our content review flagged this image as inappropriate…") on both /profile/edit and /onboarding/photos
- Generic wording is intentional — revealing the exact label would help bad actors iterate around the filter

## Test plan

- [ ] Upload a clean photo → dialog does NOT appear, photo shows in grid
- [ ] Upload a flagged image (e.g. weapon) → dialog appears after ~5s, photo does not show
- [ ] Dialog dismisses cleanly
- [ ] Works on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)