### PR TITLE
feat(ban-cascade): purge matches/messages/cache on profile.banned

### DIFF
--- a/infra/stacks/domain2_stack.py
+++ b/infra/stacks/domain2_stack.py
@@ -70,7 +70,7 @@ class Domain2Stack(cdk.Stack):
                 {"method": "GET", "path": "/matches/{matchId}", "auth": True},
                 {"method": "DELETE", "path": "/matches/{matchId}", "auth": True},
             ],
-            consume_events=["swipe.created", "user.deleted"],
+            consume_events=["swipe.created", "user.deleted", "profile.banned"],
             publish_events=True,
             environment={
                 "SWIPE_TABLE_NAME": swipe_svc.tables[0].table_name,
@@ -138,7 +138,7 @@ class Domain2Stack(cdk.Stack):
                 {"method": "GET", "path": "/recommend", "auth": True},
                 {"method": "POST", "path": "/recommend/refresh", "auth": True},
             ],
-            consume_events=["profile.completed", "swipe.created", "user.deleted"],
+            consume_events=["profile.completed", "swipe.created", "user.deleted", "profile.banned"],
             environment={
                 "DISCOVERY_TABLE_NAME": discovery_svc.tables[0].table_name,
                 "SWIPE_TABLE_NAME": swipe_svc.tables[0].table_name,

--- a/infra/stacks/domain3_stack.py
+++ b/infra/stacks/domain3_stack.py
@@ -73,7 +73,7 @@ class Domain3Stack(cdk.Stack):
                 {"method": "GET", "path": "/messages/match/{matchId}", "auth": True},
                 {"method": "DELETE", "path": "/messages/{messageId}", "auth": True},
             ],
-            consume_events=["user.deleted"],   # cleans up messages for deleted users
+            consume_events=["user.deleted", "profile.banned"],   # cleans up messages for deleted/banned users
             publish_events=True, # publishes message.sent
             environment={
                 "EVENT_BUS_NAME": event_bus.event_bus_name,

--- a/services/domain-2-discovery/match-service/lambda_function.py
+++ b/services/domain-2-discovery/match-service/lambda_function.py
@@ -26,11 +26,12 @@ def handler(event, context):
         logger.info('EventBridge: swipe.created')
         return handle_swipe_event(event)
 
-    # EventBridge event (user.deleted)
+    # EventBridge event (user.deleted or profile.banned — both purge matches)
     if event.get('source') == 'kismet.profile-service' and (
         event.get('detail-type') or event.get('detailType')
-    ) == 'user.deleted':
-        logger.info('EventBridge: user.deleted')
+    ) in ('user.deleted', 'profile.banned'):
+        detail_type = event.get('detail-type') or event.get('detailType')
+        logger.info('EventBridge: %s', detail_type)
         return handle_user_deleted(event)
 
     # API Gateway request

--- a/services/domain-2-discovery/recommendation-service/lambda_function.py
+++ b/services/domain-2-discovery/recommendation-service/lambda_function.py
@@ -34,8 +34,8 @@ def handler(event, context):
         if detail_type == 'profile.completed':
             logger.info('EventBridge: profile.completed')
             return handle_profile_completed(event)
-        if detail_type == 'user.deleted':
-            logger.info('EventBridge: user.deleted')
+        if detail_type in ('user.deleted', 'profile.banned'):
+            logger.info('EventBridge: %s', detail_type)
             return handle_user_deleted(event)
 
     # EventBridge: swipe.created → remove swiped candidate

--- a/services/domain-3-messaging/message-service/lambda_function.py
+++ b/services/domain-3-messaging/message-service/lambda_function.py
@@ -23,10 +23,10 @@ events_client = boto3.client("events")
 def lambda_handler(event: Optional[Dict[str, Any]], context: Any) -> Dict[str, Any]:
     event = event or {}
 
-    # EventBridge: user.deleted → delete all messages for the user's conversations
+    # EventBridge: user.deleted or profile.banned → purge messages for the user
     if event.get("source") == "kismet.profile-service" and (
         event.get("detail-type") or event.get("detailType")
-    ) == "user.deleted":
+    ) in ("user.deleted", "profile.banned"):
         detail = event.get("detail") or {}
         if isinstance(detail, str):
             try:


### PR DESCRIPTION
## Summary

- Before: a ban only triggered D1 profile-service + D2 discovery cleanup. The banned user stayed visible in other users' match lists and chat threads (found today when two users reported John Zhang and he remained in Jessica's matches).
- Now: match-service, message-service, and recommendation-service all listen for \`profile.banned\` and run the same purge path they use for \`user.deleted\`.
- CDK: \`consume_events\` updated in domain2 (match, recommendation) and domain3 (message) so EventBridge Rules + Lambda permissions get created.

## Event chain after this PR

\`\`\`
D4 report-service  →  user.banned
D1 profile-service →  profile.banned  (sets status=banned, emits downstream)
  ├→ D2 discovery-service      (existing) removes from discovery pool
  ├→ D2 match-service          (NEW)     purges MATCH/PAIR/USER rows
  ├→ D2 recommendation-service (NEW)     clears recommendation cache
  └→ D3 message-service        (NEW)     purges message threads
\`\`\`

## Test plan

- [ ] User A and User B both report User C → auto-ban fires (threshold=2)
- [ ] User C's profile.status transitions to \`banned\`
- [ ] User C no longer appears in anyone's discovery / recommendations
- [ ] Existing matches with User C are removed from counterparty match lists
- [ ] Existing chat threads with User C are purged

Verified live today by manually firing a synthetic \`user.banned\` for 34a80438 (John Zhang) after 2 pending reports; downstream tables showed 0 rows for that user within seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)