### PR TITLE
docs: per-domain design pack (Shared + D1/D3/D4/D5/D6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ kismet/
 │   ├── api-contracts/                ← one API contract per service (25 files)
 │   ├── system-design/
 │   │   ├── Design_Doc.md             ← high-level architecture & decisions
+│   │   ├── SharedStack_Design.md     ← deep dive: shared foundation (Cognito/API GW/EventBus/S3/CDN)
+│   │   ├── Domain1_Design.md         ← deep dive: Identity & Profiles
+│   │   ├── Domain2_Design.md         ← deep dive: Discovery & Matching
+│   │   ├── Domain3_Design.md         ← deep dive: Messaging
+│   │   ├── Domain4_Design.md         ← deep dive: Safety & Moderation
+│   │   ├── Domain5_Design.md         ← deep dive: Notifications & Engagement
+│   │   ├── Domain6_Design.md         ← deep dive: Analytics & Admin
 │   │   └── event-schema.json         ← canonical EventBridge event schemas
 │   └── guides/
 │       └── Service_Communication_Guide.md

--- a/docs/system-design/Domain1_Design.md
+++ b/docs/system-design/Domain1_Design.md
@@ -1,0 +1,299 @@
+# Domain 1 — Identity & Profiles
+
+> Detailed design for the auth, profile, photo, and email-verification services.
+> Source of truth: [`infra/stacks/domain1_stack.py`](../../infra/stacks/domain1_stack.py) + [`services/domain-1-identity/`](../../services/domain-1-identity/)
+> Last verified: Apr 16, 2026
+
+---
+
+## 1. Purpose
+
+Domain 1 is the "front door" of Kismet — it owns **who a user is, how they log in, what their profile looks like, and which photos they've uploaded**. Three Lambda services are wired into the shared REST API via `Domain1Stack`: Auth, Profile, and Photo. A fourth service, Email Verification, lives in-tree but is not currently provisioned by the stack (see §8).
+
+Downstream, D1 publishes the lifecycle events that every other domain keys off: `user.created`, `profile.completed`, `profile.updated`, `profile.banned`, `user.deleted`, and `photo.uploaded`. Upstream, D1 consumes `user.banned` from D4 (re-emitted as `profile.banned`) and — for the Photo service — its own `user.deleted` fan-out.
+
+---
+
+## 2. Architecture
+
+```
+                    ┌─────────────────────────────────┐
+                    │   Imported REST API + Cognito   │
+                    └───┬───────┬───────┬─────────────┘
+                        │       │       │
+                  ┌─────▼──┐ ┌──▼─────┐ ┌▼─────────┐
+                  │  Auth  │ │Profile │ │  Photo   │──► S3 (presigned PUT)
+                  └───┬────┘ └───┬────┘ └────┬─────┘     + CloudFront
+                      │          │           │
+                ┌─────▼──┐  ┌────▼─────┐ ┌──▼──────┐
+                │kismet- │  │ kismet-  │ │kismet-  │
+                │users   │  │ profiles │ │ photos  │
+                └────────┘  └──────────┘ └─────────┘
+
+    EventBridge: kismet-events
+      in:  user.banned (D4), user.deleted (self, to Photo)
+      out: user.created, profile.completed, profile.updated,
+           profile.banned, user.deleted, photo.uploaded
+```
+
+See [`diagrams/domain1-architecture.drawio`](./diagrams/) for the full picture with Cognito, SES, and downstream consumers.
+
+---
+
+## 3. Services
+
+### 3.1 Auth Service
+
+| | |
+|---|---|
+| **Entry** | `POST /auth/signup`, `/auth/login`, `/auth/refresh`, `/auth/logout`, `/auth/confirm` (all unauthenticated) |
+| **Table** | `kismet-users` (PK `USER#{userId}`, SK `METADATA`) |
+| **Consumes events** | none |
+| **Publishes** | `user.created` (on signup) |
+
+**Responsibilities**
+
+1. Thin shell over Cognito User Pool operations — `sign_up`, `initiate_auth` (USER_PASSWORD_AUTH and REFRESH_TOKEN_AUTH), `revoke_token`, `confirm_sign_up`.
+2. Mirror the minimal user metadata (`userId`, `email`, `createdAt`, plus optional `birthDate`/`birthTime`) into `kismet-users` so other services aren't coupled to Cognito's API surface.
+3. Publish `user.created` once the Cognito SignUp returns a `UserSub`.
+
+**Key design choices**
+
+- **Cognito is the identity source of truth.** `kismet-users` is a small denormalization keyed on `sub`, written immediately after `sign_up`. No auth verification logic lives here — JWTs are validated by API Gateway's Cognito authorizer on every other D1/D2/D3 route.
+- **Error mapping is centralized** in `_handle_cognito_error` — Cognito exception codes (`UsernameExistsException`, `NotAuthorizedException`, `CodeMismatchException`, etc.) map to stable HTTP status + `code` pairs so the frontend never sees raw AWS errors.
+- **Refresh returns the same refresh token.** Cognito's REFRESH_TOKEN_AUTH flow doesn't re-issue one; the handler echoes the original so clients can treat the response shape as uniform.
+
+### 3.2 Profile Service
+
+| | |
+|---|---|
+| **Entry** | `POST /profiles`, `GET/PUT/DELETE /profiles/{userId}` (all Cognito-authenticated) |
+| **Table** | `kismet-profiles` (PK `USER#{userId}`, SK `PROFILE`) |
+| **Consumes events** | `user.banned` (from D4 report-service) |
+| **Publishes** | `profile.completed`, `profile.updated`, `profile.banned`, `user.deleted` |
+
+**Responsibilities**
+
+1. Own the canonical user doc — name, gender, interestedIn, birthDate/birthTime, location (lat/long), city, bio, interests, avatarUrl, status.
+2. Enforce the `status ∈ {active, banned}` contract: banned profiles return 404 from `GET /profiles/{userId}` so they effectively vanish for end-users.
+3. Be the **bridge between moderation and downstream consumers**: translate D4's `user.banned` into `profile.banned` so D2/D3/D5 can wire a single upstream source. See §5.3.
+4. Fan out `user.deleted` on self-service account deletion so D1 Photo, D2, D3, and D5 can all clean up.
+
+**Key design choices**
+
+- **Strict validation on create**: `gender ∈ {male, female, non-binary}`, `interestedIn ∈ {male, female, non-binary, everyone}`, `birthDate` and `location` required. A `409 CONFLICT` is returned if a PROFILE row already exists for the user.
+- **`UPDATABLE_FIELDS` allowlist** on PUT — a client can't accidentally overwrite `status`, `createdAt`, `bannedAt`, or any moderation-set field by including it in the request body.
+- **`profile.updated` payload always reflects the post-write state.** The handler does a fresh `get_item` after `update_item` and builds the event detail from that, so D2 discovery's denormalized copy never drifts.
+- **Caller/path authz**: PUT and DELETE require `caller_id == user_id`. There is no admin edit path in this service — admin bans flow through D4 → `user.banned`.
+- **Idempotent DELETE** (#113-followup): `delete_item` on a non-existent row is a no-op, so retries after partial failure are safe. The EventBridge publish is the one thing that must succeed — a `FailedEntryCount > 0` returns 500 and the caller can retry.
+
+### 3.3 Photo Service
+
+| | |
+|---|---|
+| **Entry** | `POST /photos/upload`, `POST /photos/{photoId}/confirm`, `GET /users/{userId}/photos`, `DELETE /photos/{photoId}`, `PUT /photos/{photoId}/primary` |
+| **Table** | `kismet-photos` (PK `USER#{userId}`, SK `PHOTO#{photoId}`) |
+| **Consumes events** | `user.deleted` |
+| **Publishes** | `photo.uploaded` (on confirm only) |
+
+**Responsibilities**
+
+1. Generate presigned S3 PUT URLs so the frontend uploads directly to the `kismet-photos-*` bucket — Lambda never touches image bytes.
+2. Track per-user photo metadata and enforce the `MAX_PHOTOS_PER_USER = 6` cap.
+3. Maintain exactly one `isPrimary = True` photo per user, and mirror the primary photo's CDN URL into `kismet-profiles.avatarUrl` and `kismet-discovery.avatarUrl`.
+4. Garbage-collect on `user.deleted`: query all PHOTO rows for the user, delete each S3 object (best-effort), then delete the DynamoDB rows.
+
+**Two-step upload pattern** (#112)
+
+```
+1. POST /photos/upload          ──► returns { photoId, uploadUrl } ; row.status = "pending"
+2. PUT  {uploadUrl} (to S3)     ──► client uploads bytes directly
+3. POST /photos/{photoId}/confirm ──► row.status = "active"
+                                      publishes photo.uploaded
+                                      if primary, mirrors avatarUrl
+```
+
+The confirm endpoint exists because **D4 image-moderation needs a stable S3 object to scan**. The naive one-step flow would publish `photo.uploaded` immediately on `POST /photos/upload`, before bytes are in S3 — Rekognition would get `NoSuchKey` roughly every time. Split into two steps: the server only publishes once the client confirms the PUT succeeded.
+
+**Photo status lifecycle**
+
+```
+   pending ──(POST /confirm)──► active ──(D4 Rekognition NSFW hit)──► rejected
+```
+
+`handle_list` filters out both `pending` and `rejected` items — so a freshly uploaded-but-not-confirmed photo is invisible, and a moderation-rejected photo stops being shown to the user **and** stops being included in the profile feed D2 uses. This is what makes the D4 moderation loop work end-to-end without Photo service having to consume a moderation event: D4 writes `status=rejected` directly, and the next `GET /users/{userId}/photos` just stops returning it.
+
+**Content-type gate**: `ALLOWED_CONTENT_TYPES = {image/jpeg, image/png, image/webp}` at upload. Note Rekognition only supports JPEG/PNG — the frontend normalizes WebP/HEIC to JPEG client-side (see §7).
+
+**Primary-photo maintenance**:
+
+- First upload for a user auto-becomes primary.
+- `PUT /photos/{photoId}/primary` unsets any existing primary, sets the target, then mirrors `avatarUrl` into `kismet-profiles` and `kismet-discovery` (both guarded with `ConditionExpression: attribute_exists(PK)` so it's a no-op if the row isn't there yet).
+- `DELETE` of the primary promotes the most-recent remaining photo (by `uploadedAt`) so the user is never left avatar-less with photos still on file.
+
+### 3.4 Email Verification Service
+
+| | |
+|---|---|
+| **Entry** | `POST /verify/send`, `POST /verify/confirm`, `GET /verify/status` |
+| **Table** | `kismet-verifications` (PK `EMAIL#{email}`, SK `LATEST`) |
+| **Consumes events** | none |
+| **Publishes** | none |
+
+SES-based flow for gating signup to `.edu` addresses:
+
+1. `POST /verify/send` — rejects non-`.edu` emails, generates a 6-digit code with `secrets.choice`, writes a row with a 10-minute TTL, and sends the code via `ses.send_email` from `SES_SOURCE_EMAIL`.
+2. `POST /verify/confirm` — validates the code, flips `verified=true`, extends TTL to 30 days, removes the `code` attribute, and best-effort pushes `email_verified=true` to Cognito via `admin_update_user_attributes`. DynamoDB is source of truth; Cognito sync failure only logs a warning.
+3. `GET /verify/status` — reads from JWT `email` claim (falls back to `?email=` for local dev).
+
+**Not yet wired into `domain1_stack.py`.** The Lambda code and API contract exist, but the CDK service block, SES identity, and DynamoDB table provisioning are still open. Referenced here for completeness; currently dead code at deploy time.
+
+---
+
+## 4. Data Layer
+
+| Table | Owner | Primary key | Size profile | Notes |
+|-------|-------|-------------|--------------|-------|
+| `kismet-users` | Auth | `USER#{userId}` / `METADATA` | ~N users | denormalization of Cognito `sub`; small, rarely read |
+| `kismet-profiles` | Profile | `USER#{userId}` / `PROFILE` | ~N users | canonical profile doc; `status ∈ {active, banned}` |
+| `kismet-photos` | Photo | `USER#{userId}` / `PHOTO#{photoId}` | ≤ 6·N | `status ∈ {pending, active, rejected}`; one row per upload |
+| `kismet-verifications` | Email Verification | `EMAIL#{email}` / `LATEST` | ≤ N | DynamoDB TTL reaps expired codes; not yet provisioned |
+
+All tables use on-demand billing. No GSIs — every access pattern is direct-key or a single-PK Query.
+
+**S3**: `kismet-photos-{account}-dev` holds raw uploads. Keys are `{userId}/{photoId}.{ext}`. Frontend reads through CloudFront at `PHOTOS_CDN_BASE_URL`; presigned PUTs go direct to the bucket with a 5-minute `ExpiresIn`.
+
+**Cross-table writes**: Photo's `_update_profile_avatar` is the only cross-domain writer in D1 — it writes `avatarUrl` into both `kismet-profiles` (D1) and `kismet-discovery` (D2). Both writes are conditional on `attribute_exists(PK)` so they're safe if the target row hasn't been created yet. IAM grants for this are scoped in `domain1_stack.py` via `extra_policies`.
+
+---
+
+## 5. Event Flows
+
+### 5.1 Signup + profile creation
+
+```
+Client                Auth Service              Profile Service          EventBridge
+  │ POST /auth/signup     │                           │                       │
+  │──────────────────────►│ cognito.sign_up           │                       │
+  │                       │ put kismet-users          │                       │
+  │                       │ publish user.created ─────┼──────────────────────►│
+  │                       │                           │                       │
+  │ POST /profiles        │                           │                       │
+  │──────────────────────────────────────────────────►│ put kismet-profiles   │
+  │                                                   │ publish               │
+  │                                                   │ profile.completed ───►│
+                                                                              │
+                                         ┌────────────────────────────────────┤
+                                         ▼                                    ▼
+                                  D2 Discovery insert               D5/D6 consumers
+                                  D2 Recommendation marker
+```
+
+### 5.2 Photo upload (two-step)
+
+```
+Client            Photo Service          S3            D4 Image Moderation
+  │ POST /photos/upload  │                │                     │
+  │─────────────────────►│ presigned PUT  │                     │
+  │                      │ row.status=    │                     │
+  │◄─────────────────────│   pending      │                     │
+  │ PUT {uploadUrl}      │                │                     │
+  │─────────────────────────────────────► │ object created      │
+  │ POST /photos/{id}/confirm             │                     │
+  │─────────────────────►│ row.status=    │                     │
+  │                      │   active       │                     │
+  │                      │ publish photo.uploaded ──────────────►│
+  │                      │                │                     │ scan → if NSFW,
+  │                      │                │                     │ set row.status=rejected
+  │◄─────────────────────│ if primary,    │                     │
+  │                      │ avatarUrl sync │                     │
+```
+
+Because `handle_list` filters out `pending` and `rejected`, a moderation-rejected photo stops showing in both the user's own profile view and D2's discovery card without any further coordination.
+
+### 5.3 Ban cascade (D4 → D1 → everyone)
+
+```
+D4 Report Service
+   │ (auto-ban threshold hit, or admin resolve=ban)
+   └─── user.banned ──► EventBridge
+                           │
+                           ▼
+                    D1 Profile Service  (handle_user_banned)
+                      - set status=banned on profile row
+                      - attach banReason, banReportId, bannedAt
+                      - publish profile.banned
+                           │
+                           └─► EventBridge
+                                   │
+          ┌──────────────┬─────────┼───────────────┬────────────┐
+          ▼              ▼         ▼               ▼            ▼
+      D2 Discovery   D2 Match  D2 Recommend   D3 Message   D5 Email
+      delete pool    purge     clear cache    purge        (pending #120)
+      row            matches                  threads
+```
+
+Profile Service is the single bridge: D4 emits one event, D1 decorates + re-emits as `profile.banned`, and downstream consumers only need to listen to D1. This keeps D2/D3/D5 decoupled from D4's internal event vocabulary.
+
+### 5.4 Account deletion fan-out (#113)
+
+`DELETE /profiles/{userId}` issues three side effects in order:
+
+1. `delete_item` on the profile row (idempotent).
+2. `cognito.admin_delete_user` to free the email for re-registration (see gotcha below).
+3. `put_events` `user.deleted`.
+
+The `user.deleted` event fans out to:
+
+- **D1 Photo** — deletes S3 objects + table rows
+- **D2 Discovery / Swipe / Match / Recommendation** — purge pool row, swipes, matches, cached recommendations
+- **D3 Message** — purge conversation threads
+- **D5 Email** — purge notification preferences
+
+If the EventBridge publish fails, the handler returns 500 and the client can safely retry — the profile row is already gone, so retry re-runs Cognito delete (no-op on `UserNotFoundException`) and re-publishes.
+
+---
+
+## 6. Cross-Service Dependencies
+
+| Caller | External reads/writes | Why |
+|--------|----------------------|-----|
+| Auth | Cognito User Pool | source of identity |
+| Profile | Cognito `AdminDeleteUser` | self-service account deletion frees the email |
+| Photo | S3 `PutObject`/`GetObject`/`DeleteObject`, `kismet-profiles` (write), `kismet-discovery` (write) | presigned URLs; avatarUrl mirroring |
+| Email Verification | Cognito `AdminUpdateUserAttributes`, SES | flip `email_verified`; send code |
+
+Cross-domain writes are deliberately one-way and guarded with `ConditionExpression: attribute_exists(PK)` so Photo-service can't create phantom rows in tables it doesn't own.
+
+---
+
+## 7. Known Gotchas
+
+1. **Banned-user re-registration loophole** (#121). `handle_delete` calls `cognito.admin_delete_user`, which removes the user from the Cognito pool entirely. A banned user who hits `DELETE /profiles/me` has their Cognito record wiped and can immediately re-signup with the same email — stepping around the ban. Fix under discussion: either skip Cognito delete when `status == banned`, or flip the account to `DISABLED` instead.
+2. **No ban notification** (#120). Users currently learn they've been banned only when their next login fails or their profile 404s. `profile.banned` has no D5 consumer yet; adding one is tracked.
+3. **API Gateway stage doesn't auto-redeploy on imported-API route changes** (#118). When `POST /photos/{photoId}/confirm` was added in #112, `cdk deploy KismetDomain1` created the Resource and Method but the `dev` stage kept serving the old route set. Manual `aws apigateway create-deployment --rest-api-id ... --stage-name dev` published it. Same class of bug as D2 hit in #118; infra-level fix still open.
+4. **Rekognition rejects WebP/HEIC.** `ALLOWED_CONTENT_TYPES` at upload includes `image/webp` because the frontend supports it in the picker, but D4 moderation can only scan JPEG/PNG. The frontend now normalizes WebP/HEIC to JPEG client-side via `<canvas>` in [`frontend/src/lib/imageUtils.ts`](../../frontend/src/lib/imageUtils.ts) before calling `/photos/upload`. If that normalizer regresses, uploads still succeed but moderation silently errors.
+5. **Email verification service is code-only.** `lambda_function.py` is complete and the API contract is published, but `domain1_stack.py` has no block for it — no Lambda, no table, no SES identity. Currently not deployed.
+6. **`kismet-users` is a write-mostly denormalization.** Nothing except Auth signup writes to it, and no D1 route reads it. Kept around so we can detach from Cognito later, but dead weight today.
+7. **Photo service does best-effort S3 cleanup.** `handle_user_deleted` logs a warning and continues if `s3.delete_object` fails — the DynamoDB row is always removed. Orphaned S3 objects accumulate silently on repeated failures; no reconciler yet.
+
+---
+
+## 8. Open Follow-ups
+
+- **#118** — CDK: imported API Gateway stage auto-redeploy (blocks D1 route additions from landing cleanly)
+- **#120** — Ban notification email (wire D5 to `profile.banned`; user learns why account is restricted)
+- **#121** — Banned-user re-registration loophole (fix `handle_delete` to skip / soft-disable Cognito when banned)
+- **Email Verification stack wiring** — provision the Lambda, table, SES identity, and routes in `domain1_stack.py`
+- **Orphaned S3 reconciler** — periodic job to diff bucket keys against `kismet-photos` rows
+- **`kismet-users`** — decide whether to keep as write-mostly denormalization or retire
+
+---
+
+## 9. References
+
+- API contracts: [`docs/api-contracts/domain-1-auth-service.md`](../api-contracts/domain-1-auth-service.md), [`domain-1-profile-service.md`](../api-contracts/domain-1-profile-service.md), [`domain-1-photo-service.md`](../api-contracts/domain-1-photo-service.md), [`domain-1-email-verification-service.md`](../api-contracts/domain-1-email-verification-service.md)
+- Event shapes: [`event-schema.json`](./event-schema.json)
+- Shared infra (Cognito user pool, REST API, S3 bucket, CloudFront): [`shared_stack.py`](../../infra/stacks/shared_stack.py)
+- Reusable Lambda + DDB + route + IAM construct: [`kismet_constructs/kismet_service.py`](../../infra/kismet_constructs/kismet_service.py)
+- Companion doc: [`Domain2_Design.md`](./Domain2_Design.md) — downstream consumers of every D1 event

--- a/docs/system-design/Domain3_Design.md
+++ b/docs/system-design/Domain3_Design.md
@@ -1,0 +1,267 @@
+# Domain 3 — Messaging
+
+> Detailed design for the chat gateway, message persistence, presence, and AI icebreaker services.
+> Source of truth: [`infra/stacks/domain3_stack.py`](../../infra/stacks/domain3_stack.py) + [`services/domain-3-messaging/`](../../services/domain-3-messaging/)
+> Last verified: Apr 16, 2026
+
+---
+
+## 1. Purpose
+
+Domain 3 is the "conversation surface" of Kismet — once two users match in D2, everything they send, see, and sense about each other in real time lives here. It owns four Lambda services backed by four DynamoDB tables, plus a **dedicated WebSocket API Gateway** that is *not* the shared REST API the rest of the system uses.
+
+Upstream, D3 consumes `match.created` (from D2) to pre-generate icebreakers, and `user.deleted` / `profile.banned` (from D1) to purge conversation history. Downstream, D3 publishes `message.sent` which fans out to D4 (Text Moderation) and D5 (Push Notifications).
+
+The real-time characteristics are the hard part of D3: WebSocket connection lifecycle, heartbeat TTLs, Bedrock cold starts, and client-side state reconciliation. All four have bitten us — see §7.
+
+---
+
+## 2. Architecture
+
+See [`diagrams/domain3-architecture.drawio`](./diagrams/domain3-architecture.drawio).
+
+```
+                    ┌─────────────────────────────────┐       ┌─────────────────────────────┐
+                    │   Imported REST API + Cognito   │       │   WebSocket API (D3-owned)  │
+                    │   (from SharedStack)            │       │   kismet-chat-ws /dev       │
+                    └───┬────────┬────────┬───────────┘       └──┬──────────┬─────────┬─────┘
+                        │        │        │                      │$connect  │$default │$disc
+                   ┌────▼──┐ ┌───▼──┐ ┌───▼──────┐          ┌────▼────┐ ┌───▼──────┐ ┌▼──────┐
+                   │Message│ │Presnc│ │Icebreaker│          │ connect │ │send_msg  │ │discon │
+                   └───┬───┘ └──┬───┘ └────┬─────┘          └────┬────┘ └────┬─────┘ └──┬────┘
+                       │        │          │                    │            │          │
+                       │        │          │  Bedrock           │            │invoke    │
+                       │        │          ├──► Claude Haiku    │            │Message   │
+                       │        │          │                    │            │Service   │
+                       ▼        ▼          ▼                    ▼            ▼          ▼
+             kismet-messages  kismet-      kismet-         kismet-connections (GSI: matchId-index)
+             (GSI:            presence     icebreakers
+              messageId-idx)  kismet-
+                              typing
+
+    EventBridge: kismet-events
+      in:  match.created (→ Icebreaker), user.deleted + profile.banned (→ Message)
+      out: message.sent
+```
+
+---
+
+## 3. Services
+
+### 3.1 Chat Gateway (WebSocket)
+
+| | |
+|---|---|
+| **Entry** | `wss://<api-id>.execute-api.us-east-1.amazonaws.com/dev?userId={sub}&matchId={matchId}` |
+| **Table** | `kismet-connections` (PK=`CONN#{connectionId}` / SK=`META`, GSI `matchId-index`) |
+| **Consumes events** | none |
+| **Publishes** | none (indirect — invokes Message Service which publishes `message.sent`) |
+
+**Three Lambdas behind one WebSocket API** (`kismet-chat-ws`), each wired to a built-in WebSocket route:
+
+| Route | Lambda | Handler file |
+|-------|--------|--------------|
+| `$connect` | `kismet-ws-connect` | `connect.py` |
+| `$disconnect` | `kismet-ws-disconnect` | `disconnect.py` |
+| `$default` | `kismet-ws-send-message` | `send_message.py` |
+
+**Critical: this is a separate `apigwv2.WebSocketApi` resource owned by `Domain3Stack`, not the shared REST API from `SharedStack`.** Two different API Gateway IDs, two different URLs, two different auth models. REST uses the Cognito authorizer; the WebSocket API has no native authorizer and instead validates on `$connect` by reading `userId` and `matchId` from the query string and confirming participation via a `kismet-matches` lookup.
+
+**Connection lifecycle**
+
+1. `$connect` — `connect.py` pulls `userId` and `matchId` from `queryStringParameters`, does `matches_table.get_item(MATCH#{matchId}, META)`, rejects with 404 if no match or 403 if the user is not in `{userAId, userBId}`, then writes `CONN#{connectionId}` / `META` with a 24-hour `ttl` attribute. The TTL is a safety net for zombie connections the API Gateway forgets to signal.
+2. `$default` — any frame the client sends (including `{"action":"sendMessage",...}`) hits `send_message.py`. It re-reads the connection row to recover `userId` + `matchId` (never trust the frame), invokes the Message Service Lambda via `lambda:Invoke` with a synthesized REST-shaped event, then queries `kismet-connections` by `matchId-index`, filters to the recipient's connections, and `post_to_connection`s the persisted message as `{"type":"newMessage", ...}`. Stale connection IDs surface as `GoneException`, which the handler catches and opportunistically deletes from the table.
+3. `$disconnect` — `disconnect.py` unconditionally deletes `CONN#{connectionId}` / `META`.
+
+**Only the recipient is pushed, not the sender.** The filter is `c["connectionId"] != connection_id and c.get("userId") == recipient_id`. This is deliberate — the sender already has an optimistic message in UI state, so echoing to them would guarantee a duplicate. (It did not, historically, prevent duplicates by itself — see §7.1.)
+
+### 3.2 Message Service
+
+| | |
+|---|---|
+| **Entry** | `POST /messages`, `POST /messages/read`, `GET /messages/match/{matchId}`, `DELETE /messages/{messageId}` (all Cognito-auth) |
+| **Table** | `kismet-messages` (PK=`CONV#{matchId}` / SK=`MSG#{timestamp}#{messageId}`, GSI `messageId-index`) |
+| **Consumes events** | `user.deleted`, `profile.banned` |
+| **Publishes** | `message.sent` |
+
+**Responsibilities**
+
+1. Persist messages, enforce "sender must be a participant of the match" on every write, and publish `message.sent`.
+2. Serve paginated history — `GET /messages/match/{matchId}` queries with `ScanIndexForward=False`, caps `limit` at 50, filters soft-deleted rows client-side, and base64-encodes `LastEvaluatedKey` as an opaque `nextCursor`.
+3. Soft-delete via `DELETE /messages/{messageId}` — looks up the row through the `messageId-index` GSI (SK embeds the timestamp, so there's no way to build the key from just a messageId), verifies caller is the sender, and sets `deleted=True` + `deletedAt`.
+4. **Purge on user lifecycle events** — when a `user.deleted` or `profile.banned` event arrives, walk every `USER#{userId}` / `MATCH#*` row in `kismet-matches` to enumerate the user's conversations, then paginate-and-batch-delete every `CONV#{matchId}` message. Paginating both outer and inner queries is required because batch_writer only takes 25 items per flush and a heavy talker can easily accrue >1000 messages.
+
+**Message Service also has a WebSocket escape hatch.** The stack injects `WEBSOCKET_ENDPOINT` (the callback URL of the D3 WebSocket API) and `execute-api:ManageConnections` IAM so the service can push read-receipts directly to connected clients without going through Chat Gateway. As of Apr 16 the `POST /messages/read` handler is declared as a route in CDK but the handler body doesn't ship it yet — the plumbing exists, the behavior doesn't.
+
+**Ban cascade (#119)** — the event filter matches `source == "kismet.profile-service"` AND `detail-type in ("user.deleted", "profile.banned")`. Both events route to the same `handle_user_deleted` path; the only difference is what upstream produced them (self-service deletion vs moderation ban). The stack's `consume_events` array lists both, which `KismetService` turns into two EventBridge rules with the same Lambda target.
+
+### 3.3 Presence Service
+
+| | |
+|---|---|
+| **Entry** | `POST /presence/heartbeat`, `GET /presence/user/{userId}`, `POST /presence/{matchId}/typing`, `GET /presence/{matchId}/typing` |
+| **Tables** | `kismet-presence`, `kismet-typing` (both with DynamoDB TTL) |
+| **Consumes events** | none |
+| **Publishes** | none |
+
+**Online/offline via TTL, not a background job.** The presence row is `USER#{userId}` / `STATUS` with `ttl = now + 60s`. The frontend heartbeats every ~30s; if three successive heartbeats miss, DynamoDB's TTL sweeper removes the row within ~10 min (usually much faster). `GET /presence/user/{userId}` simply `get_item`s — a missing row is treated as offline (returned as 404 today; see §7.4).
+
+**Typing indicators via a 5-second TTL.** `POST /presence/{matchId}/typing` writes `MATCH#{matchId}#USER#{userId}` / `TYPING` with `ttl = now + 5s`. `GET` reads the *other* participant's typing row (computed from the match's `userAId`/`userBId`). If the row is present, they're typing; if it's gone, they stopped or TTL expired. No WebSocket fan-out — the frontend polls this endpoint while the composer is focused.
+
+Both tables were created as raw `dynamodb.Table` resources instead of through `KismetService` because the shared construct doesn't expose `time_to_live_attribute`. The service's `tables=[]` kwarg is empty for that reason; IAM is granted manually on the next lines of the stack.
+
+### 3.4 Icebreaker Service
+
+| | |
+|---|---|
+| **Entry** | `POST /icebreaker/generate`, `GET /icebreaker/{matchId}` |
+| **Table** | `kismet-icebreakers` (PK=`MATCH#{matchId}` / SK=`META`) |
+| **Consumes events** | `match.created` |
+| **Publishes** | none |
+
+**Bedrock with a hardcoded-template fallback.** On `match.created`, the handler fires `_generate_and_cache` with empty user dicts, calling Claude Haiku (`anthropic.claude-3-haiku-20240307-v1:0`) via Bedrock Runtime to generate 3 openers. The prompt asks for a JSON array of strings, the response is `json.loads`-ed, and rows are written as `{id: "ice-001", text, source: "bedrock" | "template"}`. Any exception — quota, cold start, malformed JSON — falls through to three hardcoded strings in `FALLBACK_ICEBREAKERS`, tagged `source: "template"` so the frontend can badge them if it wants.
+
+**Pre-generation beats on-demand.** The `match.created` handler writes the cache *before* either user opens the chat; by the time the frontend calls `GET /icebreaker/{matchId}` the row already exists. `POST /icebreaker/generate` is the on-demand fallback — it returns the cache if present, else regenerates. The GET route returns `suggestions: null` (not 404) when nothing's cached, so the frontend can render an empty state without special-casing errors.
+
+**Note**: the EventBridge handler ignores the `userA` / `userB` body fields (it passes `{}` to `_call_bedrock`), so auto-generated openers are always generic until the user opens chat and triggers `POST /icebreaker/generate` with profile data — but by then the cached generic version returns first. This is effectively a bug; see §8.
+
+---
+
+## 4. Data Layer
+
+| Table | Primary key | Size profile | Notes |
+|-------|-------------|--------------|-------|
+| `kismet-messages` | PK `CONV#{matchId}` / SK `MSG#{timestamp}#{messageId}` | unbounded, ~chat-volume | GSI `messageId-index` for DELETE; soft-delete via `deleted` flag |
+| `kismet-connections` | PK `CONN#{connectionId}` / SK `META` | ~online-users, TTL 24h | GSI `matchId-index` to fan out sends |
+| `kismet-presence` | PK `USER#{userId}` / SK `STATUS` | ~online-users, TTL 60s | missing row = offline |
+| `kismet-typing` | PK `MATCH#{matchId}#USER#{userId}` / SK `TYPING` | ~actively-typing, TTL 5s | one row per typist |
+| `kismet-icebreakers` | PK `MATCH#{matchId}` / SK `META` | ~total-matches | one row per match, pre-generated |
+
+All tables are on-demand billing. `kismet-connections`, `kismet-presence`, and `kismet-typing` all use DynamoDB TTL on a `ttl` attribute (Unix epoch seconds). `kismet-messages` and `kismet-icebreakers` do not expire — history is permanent.
+
+D3 also has cross-domain read access to `kismet-matches` (owned by D2) in every service for participant-of-match checks. No writes ever cross the domain boundary.
+
+---
+
+## 5. Event Flows
+
+### 5.1 Sending a message (WebSocket path)
+
+```
+Client ─(WSS frame)─► $default ─► send_message.py
+                                     │
+                                     │  get_item CONN#{connId}  (recover userId/matchId)
+                                     │  get_item MATCH#{matchId} (authz)
+                                     │
+                                     └─► lambda:Invoke MessageService (synthesized REST event)
+                                                  │
+                                                  │  put_item CONV#{matchId}/MSG#{ts}#{msgId}
+                                                  │
+                                                  └─► events:PutEvents message.sent
+                                                              │
+                                                              ├─► D4 Text Moderation
+                                                              └─► D5 Push Notification
+                                     │
+                                     │  query matchId-index, filter by recipient userId
+                                     └─► post_to_connection(recipient connectionId, {type:"newMessage",...})
+```
+
+### 5.2 Match created → icebreakers pre-generated
+
+```
+D2 Match Service ─ match.created ─► EventBridge
+                                         │
+                                         ├─► D3 Icebreaker (this domain)
+                                         │      - _generate_and_cache(matchId)
+                                         │      - bedrock.invoke_model (Claude Haiku)
+                                         │      - put_item MATCH#{matchId}/META
+                                         │
+                                         ├─► D5 Push Notification
+                                         └─► D6 Analytics
+```
+
+### 5.3 Ban or delete cascade
+
+```
+D1 Profile Service
+    │  (user.deleted self-service OR profile.banned from moderation)
+    └─── EventBridge ──► D3 Message Service
+                           │
+                           │  query kismet-matches USER#{userId}/MATCH#*
+                           │  for each matchId:
+                           │    paginate CONV#{matchId}
+                           │    batch_writer.delete_item per message
+                           │
+                           └─► (no outbound event — D2 also consumes and handles the match row)
+```
+
+Presence, typing, connections, and icebreakers are *not* purged by this path. Rationale:
+- `kismet-presence` / `kismet-typing` self-expire within 60s / 5s anyway.
+- `kismet-connections` self-expires in 24h and the next `$connect` will fail authz after the match is deleted in D2.
+- `kismet-icebreakers` is keyed by `matchId` — once D2 deletes the match row, the icebreaker cache is unreachable dead weight but doesn't leak PII. Cleanup is on the follow-up list (§8).
+
+---
+
+## 6. Cross-Service Dependencies
+
+| Caller | Reads (other svc's table) | Why |
+|--------|---------------------------|-----|
+| Chat Gateway `connect` / `send_message` | `kismet-matches` | Participant-of-match authz |
+| Message Service | `kismet-matches` | Participant check + enumerate user's matches on ban/delete |
+| Presence Service | `kismet-matches` | Participant check for typing endpoints |
+| Icebreaker Service | `kismet-matches` | Participant check for generate/get |
+| Message Service | `kismet-connections` | Push read-receipts via `execute-api:ManageConnections` |
+| Chat Gateway `send_message` | MessageService Lambda | `lambda:Invoke` for persistence |
+
+Writes to `kismet-messages` only happen from Message Service. Chat Gateway never writes to the messages table directly — it invokes the service Lambda with a synthesized REST event. This keeps the event-publishing path single-sourced and avoids two writers competing on the same `CONV#{matchId}` partition.
+
+---
+
+## 7. Known Gotchas / Postmortem Highlights
+
+### 7.1 Chat duplicate messages ([postmortem](../postmortem/chat-duplicate-messages-2026-04-14.md))
+
+The sender saw every message 2-3 times. Three independent writers (optimistic insert with a `temp-*` id, the WebSocket echo with the real uuid, and a 5-second HTTP poll with the same uuid) each appended to React state; dedup by `messageId` failed because temp and server IDs never match. **Backend was not the fault** — Chat Gateway already excludes the sender's connection from the broadcast. Fix was client-side: WebSocket became a *notification* that triggers `fetchMessages()` (which fully replaces state), not a data channel. Optimistic `temp-*` rows live ~1s until the next fetch overwrites them. Takeaway: do not build a client-side CRDT when the server is the source of truth.
+
+### 7.2 D3 route revert (#83 / [postmortem](../postmortem/d3-route-revert-2026-04-12.md))
+
+PR #89 was branched off main *before* PR #86's route-conflict fix merged. On merge, the old `domain3_stack.py` (with `/messages/{matchId}` and `/presence/{userId}` — both colliding with other path variables at the REST API level) came back with it, breaking `cdk deploy KismetDomain3` twice into `ROLLBACK_COMPLETE`. All D3 endpoints were down for ~2 hours. Fix was PR #97 re-applying the new paths (`/messages/match/{matchId}`, `/presence/user/{userId}`), manual CloudFormation stack deletion, and redeploy. Process lesson: rebase before merging any PR that touches a CDK stack file; coordinate edits to `domain3_stack.py`.
+
+### 7.3 iOS `Load failed` ([postmortem](../postmortem/ios-fetch-load-failed-2026-04-14.md))
+
+iOS WebKit silently blocked cross-origin `fetch()` to API Gateway — CORS preflight succeeded, the actual request threw `TypeError: Load failed` at the network layer. The D3 chat page was the canary because it was the first route the user hit after login. Fix was a Next.js catch-all proxy at `/api/proxy/[...path]` making all browser requests same-origin (Vercel → API Gateway server-to-server). **WSS was not affected** and still connects directly to the D3 WebSocket API — WebSocket traffic works fine on iOS. So the chat page has a mixed transport model today: REST goes through the proxy, WebSocket is direct.
+
+### 7.4 Presence 404 vs offline
+
+`GET /presence/user/{userId}` returns 404 when no row exists for that user. Semantically this conflates "user has never heartbeated" with "user is currently offline (TTL expired)." The frontend treats 404 as offline, which is fine, but any future alerting on 404 rates will be misleading. Consider returning `200 {status: "offline"}` on miss.
+
+### 7.5 WebSocket stage URL is not stable across deploys
+
+The WebSocket API is created fresh each time `KismetDomain3` is recreated (as happened during the #83 incident), and `api_id` is generated by CloudFormation. Current URL is emitted as a CfnOutput (`ChatWebSocketUrl`). Frontend hardcodes this in `NEXT_PUBLIC_WS_URL` — any stack recreation requires a Vercel env var update and redeploy.
+
+### 7.6 Icebreaker auto-generation ignores user profiles
+
+The `match.created` branch calls `_generate_and_cache(matchId, user_a={}, user_b={})` with empty profiles, so the cached openers are always generic ("a college student ... a college student"). The `POST /icebreaker/generate` path does pass profile data from the body, but it short-circuits on the cache hit that EventBridge already wrote. Net effect: personalization never happens for auto-generated icebreakers.
+
+---
+
+## 8. Open Follow-ups
+
+- **#119 ban-cascade** — extended Message Service to consume `profile.banned`; keep both event filters wired (user-initiated vs moderation-initiated). Mirror of D2's same change.
+- **Icebreaker personalization** — the EventBridge handler should fetch profile data for `userAId` / `userBId` from D1 (or receive it in the event payload) before invoking Bedrock. Current auto-generation is effectively degraded to template mode.
+- **Icebreaker cache on match delete** — no cleanup path; rows outlive their `matchId`. Low priority (no PII, just orphaned AI output) but worth a `match.deleted` consumer eventually.
+- **Read receipts** — CDK declares `POST /messages/read` and the env + IAM for WebSocket push are wired, but the handler body isn't implemented. Stub route currently 404s at dispatch.
+- **Presence offline semantics** — return `200 {status:"offline"}` instead of 404 so the frontend doesn't have to treat a missing row as an error.
+- **WebSocket auth via query param** — `?userId=<sub>` is trust-on-first-read; a forged `userId` that matches an existing match participant would pass `$connect`. Long-term: pass a JWT and verify it in `$connect` like the REST side.
+- **`cdk synth` in CI** — action item from the #83 postmortem; would have caught the route-conflict regression before merge.
+
+---
+
+## 9. References
+
+- API contracts: [`docs/api-contracts/domain-3-*.md`](../api-contracts/)
+- Event shapes: [`event-schema.json`](./event-schema.json)
+- Shared infra: [`shared_stack.py`](../../infra/stacks/shared_stack.py)
+- Reusable Lambda + DDB + route + IAM construct: [`kismet_constructs/kismet_service.py`](../../infra/kismet_constructs/kismet_service.py)
+- Postmortems: [`chat-duplicate-messages-2026-04-14.md`](../postmortem/chat-duplicate-messages-2026-04-14.md), [`d3-route-revert-2026-04-12.md`](../postmortem/d3-route-revert-2026-04-12.md), [`ios-fetch-load-failed-2026-04-14.md`](../postmortem/ios-fetch-load-failed-2026-04-14.md)
+- Sibling domain doc: [`Domain2_Design.md`](./Domain2_Design.md)

--- a/docs/system-design/Domain4_Design.md
+++ b/docs/system-design/Domain4_Design.md
@@ -1,0 +1,286 @@
+# Domain 4 — Safety & Moderation
+
+> Detailed design for the text-moderation, image-moderation, report, and rate-limiter services.
+> Source of truth: [`infra/stacks/domain4_stack.py`](../../infra/stacks/domain4_stack.py) + [`services/domain-4-moderation/`](../../services/domain-4-moderation/)
+> Last verified: Apr 16, 2026
+
+---
+
+## 1. Purpose
+
+Domain 4 is the **safety net** of Kismet — it decides what user-generated content is allowed on the platform, and it is the only domain that can cause a user to be removed against their will. It owns four Lambda services: two ML-backed content scanners (text, image), one user-facing report pipeline with admin resolution, and one Redis-backed per-user rate limiter.
+
+Upstream, D4 consumes two data events: `message.sent` (from D3 Message Service) and `photo.uploaded` (from D1 Photo Service). Downstream, D4 publishes `content.flagged`, `user.reported`, and — critically — `user.banned`, which D1 Profile Service turns into a `profile.banned` fan-out that D2 (Discovery/Match/Recommendation) and D3 (Message) consume to purge the banned user's footprint.
+
+Report Service and Image Moderation are the only services in the codebase that can cause *destructive* state changes for other users (match deletion, photo rejection, account ban). That concentration is deliberate — everything dangerous lives behind one review surface.
+
+---
+
+## 2. Architecture
+
+```
+                    ┌─────────────────────────────────┐
+                    │   Imported REST API + Cognito   │
+                    └───┬─────┬─────┬─────┬───────────┘
+                        │     │     │     │
+              ┌─────────▼─┐ ┌─▼───┐ ┌▼────┐ ┌▼──────────┐
+              │  Text     │ │Img  │ │Rep  │ │ RateLimit │
+              │ Moderate  │ │Mod  │ │ort  │ │  (VPC)    │
+              └────┬──────┘ └──┬──┘ └──┬──┘ └─────┬─────┘
+                   │           │      │           │
+            ┌──────▼───┐ ┌─────▼──┐ ┌─▼─────┐  ┌──▼──────┐
+            │ Comprehend│ │Rekogn. │ │ SES   │  │ Redis   │
+            │ DetectTox.│ │DetectM.│ │ admin │  │ Elasti- │
+            └──────┬────┘ └─────┬──┘ └───────┘  │ Cache   │
+                   │            │               └─────────┘
+            ┌──────▼────┐ ┌─────▼─────────┐ ┌───────────┐
+            │ text-mod  │ │ image-mod    │ │  reports  │
+            │ table +GSI│ │ table +GSI   │ │ +2 GSIs   │
+            └───────────┘ └──────┬───────┘ └───────────┘
+                                 │ (UpdateItem status=rejected)
+                           ┌─────▼──────┐
+                           │ kismet-    │
+                           │ photos (D1)│
+                           └────────────┘
+
+    EventBridge: kismet-events
+      in:  message.sent, photo.uploaded
+      out: content.flagged, user.reported, user.banned
+```
+
+See [`diagrams/domain4-architecture.drawio`](./diagrams/domain4-architecture.drawio).
+
+---
+
+## 3. Services
+
+### 3.1 Text Moderation Service
+
+| | |
+|---|---|
+| **Entry** | `POST /moderate/text`, `GET /moderate/text/history` (admin-only), EventBridge `message.sent` |
+| **Table** | `kismet-text-moderation-dev` (PK=`contentId`, SK=`sk`; GSI `gsi1` on `gsi1pk`/`gsi1sk:N`) |
+| **Consumes** | `message.sent` |
+| **Publishes** | `content.flagged` |
+
+**Responsibilities**
+1. Classify arbitrary text (message body or bio) with AWS Comprehend `DetectToxicContent`.
+2. Persist the full result — toxicity score, category labels, timestamp — to the moderation table for admin audit.
+3. On a flag, emit `content.flagged` so D5 / admin surfaces know.
+
+**Key design choices**
+- Two tunable thresholds, independent: `TOXICITY_THRESHOLD` (default 0.65) controls the flag decision; `CATEGORY_SCORE_FLOOR` (default 0.35) controls which category labels are recorded alongside the score. Scores always come back 0.0–1.0 from Comprehend.
+- History pagination uses a `gsi1pk = "TEXT_MODERATION_HISTORY"` GSI with `gsi1sk = int(time.time() * 1000)` so admin list is descending by time without a sort-client-side step.
+- For `message` type, `content.flagged` needs a `userId` — the event consumer extracts `senderId` from the `message.sent` detail. If it's missing, the service **logs and skips** rather than publishing an anonymous flag event (the comment in `run_moderation` is explicit: "check message-service senderId"). For `bio` type, `userId` falls back to `contentId` itself.
+- Content is capped at `CONTENT_MAX_BYTES = 4500` — under Comprehend's 5 KB per-segment limit.
+
+### 3.2 Image Moderation Service
+
+| | |
+|---|---|
+| **Entry** | `POST /moderate/image`, `GET /moderate/image/history` (admin-only), EventBridge `photo.uploaded` |
+| **Table** | `kismet-image-moderation-dev` (PK=`photoId`, SK=`sk`; GSI `gsi1` on `gsi1pk`/`gsi1sk:N`) |
+| **Consumes** | `photo.uploaded` |
+| **Publishes** | `content.flagged` |
+| **Cross-writes** | `kismet-photos` (sets `status=rejected`) |
+
+**Responsibilities**
+1. Run AWS Rekognition `DetectModerationLabels` against the S3 object at `detail.s3Bucket` / `detail.s3Key`.
+2. Flag if `max(label.Confidence) >= MODERATION_FLAG_CONFIDENCE` (default **60**, tunable via env).
+3. On a flag: emit `content.flagged` **and** `UpdateItem` on `kismet-photos` (PK=`USER#{userId}`, SK=`PHOTO#{photoId}`) setting `status = "rejected"`.
+
+**Key design choices**
+- **Bucket resolution precedence** — `detail.s3Bucket` from the event wins over `PHOTO_S3_BUCKET` env, by design (event-schema contract). A mismatch is logged, not rejected, so environment drift doesn't block moderation.
+- **Two Rekognition confidence knobs**: `REKOGNITION_MIN_CONFIDENCE` (default **5**) is passed to the API so the raw label list stays broad; `MODERATION_FLAG_CONFIDENCE` (default **60**) is applied locally to decide `flagged`. This lets us record low-confidence labels for admin review without auto-flagging everything.
+- **Reason slug**: the top label name (e.g. "Explicit Nudity") is normalized to `explicit_nudity` for the `content.flagged` `reason` field, so downstream consumers can filter without brittle string matching.
+- **Photo row cross-write is best-effort**: if the `UpdateItem` on `kismet-photos` fails, we log but do not re-raise — the moderation record is already persisted and the flag event is already published. Re-running moderation on a re-uploaded photo re-issues the update.
+
+### 3.3 Report Service
+
+| | |
+|---|---|
+| **Entry** | `POST /reports`, `GET /reports?status=&limit=&cursor=` (admin), `GET /reports/{reportId}` (admin), `PUT /reports/{reportId}/resolve` (admin) |
+| **Table** | `kismet-reports` (PK=`pk`, SK=`sk`; GSI `reportedUserId-index`, GSI `status-index`) |
+| **Consumes** | none |
+| **Publishes** | `user.reported`, `user.banned` |
+| **External** | SES admin alert on new reports |
+
+**Responsibilities**
+1. Let any authenticated user file a report on another user with a bounded reason enum (`harassment`, `inappropriate_content`, `spam`, `fake_profile`, `other`).
+2. Dedupe: one PENDING report per (reporter, reportedUser) pair — a second POST while the first is unresolved returns `409`.
+3. **Auto-ban at threshold** (added in PR #114): after every successful POST, query the `reportedUserId-index` GSI and count PENDING reports for the reported user. If `count >= AUTO_BAN_THRESHOLD` (default **2**), mark all PENDING reports for that user as `RESOLVED` with `resolution = "ban"` and fire `user.banned`.
+4. Let admins resolve individual reports with `warning | ban | dismiss`. A `ban` resolution also fires `user.banned`.
+5. SES-email an admin alert on every new report (non-blocking — failures are logged).
+
+**Key design choices**
+- **GSI for the auto-ban count**, not a scan. `_count_pending_reports_for_user` paginates via `Key('reportedUserId').eq(...)` with a `FilterExpression` on status and `Select='COUNT'`. Cost stays O(reports against *this* user), not O(all reports).
+- **`GET /reports?status=PENDING`** (added in #114) uses a scan with a filter expression. There is a `status` GSI declared in CDK but the handler doesn't query it yet — follow-up opportunity once volume justifies.
+- **Conditional resolve**: `PUT /resolve` uses `ConditionExpression: attribute_exists(pk) AND #status = :PENDING` so a double-resolve under two admin tabs returns `409 CONFLICT`.
+- **`user.reported` vs `user.banned`**: every report emits `user.reported` (for activity logging / analytics). Only a ban path (auto or admin-resolved) emits `user.banned`. Consumers treat them as different severity tiers — `user.reported` is informational; `user.banned` triggers destructive cleanup in D1/D2/D3.
+- Report list responses strip `description`, `resolution`, `resolvedAt` from the summary view; the detail GET returns the full row.
+
+### 3.4 Rate Limiter Service
+
+| | |
+|---|---|
+| **Entry** | `GET /ratelimit/status/{userId}` (admin), `POST /ratelimit/reset/{userId}` (admin) |
+| **Storage** | ElastiCache Redis `cache.t3.micro`, single node, in VPC PRIVATE_ISOLATED subnet |
+| **Consumes** | none |
+| **Publishes** | none |
+
+**Responsibilities**
+1. Expose a `check_rate_limit(user_id, action)` function importable by other Lambdas — sliding-window counters in Redis.
+2. Admin endpoints to inspect and reset counters.
+
+**Limit table** (hard-coded in `LIMITS`):
+
+| Action | Limit | Window |
+|--------|-------|--------|
+| `swipes` | 100 | 24 h (calendar UTC day) |
+| `messages` | 50 | 1 h (calendar UTC hour) |
+| `reports` | 5 | 24 h (calendar UTC day) |
+
+**Key design choices**
+- **Calendar-aligned windows, not true sliding**: `get_window_info` snaps to the start of the current UTC day or hour so all users share a reset boundary. This avoids sophisticated sorted-set algorithms and keeps each check to a single `INCR`.
+- **Key shape**: `ratelimit:{userId}:{action}:{windowStartEpochMs}`. TTL set to `windowSeconds + 60` on first increment. Old windows age out naturally.
+- **Fail-open**: if Redis is unreachable, `check_rate_limit` returns `{"allowed": True}`. Rate-limiting is a best-effort guardrail, not a correctness boundary — outages never block users.
+- **VPC-attached**: the Lambda is in the same VPC/SG as the Redis cluster. Other domains that want rate limiting would currently have to duplicate the VPC attachment or call a (not-yet-built) internal HTTP endpoint. See Open Follow-ups.
+
+---
+
+## 4. Data Layer
+
+| Table / Store | Primary key | GSIs | Notes |
+|---------------|-------------|------|-------|
+| `kismet-text-moderation-dev` | `contentId` / `sk="RESULT"` | `gsi1`: `gsi1pk="TEXT_MODERATION_HISTORY"` / `gsi1sk:N` (millis) | one row per moderated text; GSI drives descending admin history |
+| `kismet-image-moderation-dev` | `photoId` / `sk="RESULT"` | `gsi1`: `gsi1pk="IMAGE_MODERATION_HISTORY"` / `gsi1sk:N` | same pattern; admin review via GSI |
+| `kismet-reports` | `pk="REPORT#{reportId}"` / `sk="META"` | `reportedUserId-index` (PK `reportedUserId` / SK `createdAt`), `status-index` (PK `status` / SK `createdAt`) | auto-ban counting uses `reportedUserId-index`; `status-index` declared but not yet queried |
+| ElastiCache Redis | `ratelimit:{userId}:{action}:{windowStart}` | n/a | single-node t3.micro, VPC-isolated |
+| `kismet-photos` (**read/write, owned by D1**) | `PK=USER#{userId}` / `SK=PHOTO#{photoId}` | n/a for this write | image-mod sets `status=rejected` only |
+
+All DynamoDB tables use on-demand billing. Nothing in D4 requires transactional writes today; the auto-ban loop issues per-item updates and accepts best-effort consistency (see Gotchas).
+
+---
+
+## 5. Event Flows
+
+### 5.1 Message moderation
+
+```
+D3 Message Service ── POST /messages ──► kismet-messages put
+       │
+       └─── message.sent ──► EventBridge
+                                 │
+                                 ▼
+                          Text Moderation
+                          - Comprehend DetectToxicContent
+                          - persist row
+                          - if score >= 0.65:
+                              content.flagged ──► D5 / admin / D6
+```
+
+### 5.2 Photo moderation
+
+```
+D1 Photo Service ── S3 put + POST /photos ──► kismet-photos put (status=pending)
+       │
+       └─── photo.uploaded (s3Bucket, s3Key, photoId, userId) ──► EventBridge
+                                 │
+                                 ▼
+                          Image Moderation
+                          - Rekognition DetectModerationLabels
+                          - persist row
+                          - if maxConfidence >= 60:
+                              content.flagged            ──► D5 / admin / D6
+                              UpdateItem kismet-photos   status=rejected
+```
+
+### 5.3 Report → auto-ban → cascade
+
+```
+User ── POST /reports ──► Report Service
+                              - put PENDING row
+                              - query reportedUserId-index (COUNT)
+                              - SES admin alert (best-effort)
+                              - user.reported ──► D6 Activity Logger
+                              │
+                              │ if pendingCount >= AUTO_BAN_THRESHOLD (2):
+                              ├─ UpdateItem all PENDING → RESOLVED, resolution="ban"
+                              └─ user.banned ──► EventBridge
+                                                     │
+                                                     ▼
+                                              D1 Profile Service
+                                              - set profile.status = banned
+                                              - publish profile.banned
+                                                     │
+                                                     └─► EventBridge
+                                                             │
+                            ┌────────────────┬───────────────┼───────────────┐
+                            ▼                ▼               ▼               ▼
+                        D2 Discovery     D2 Match      D2 Recommend      D3 Message
+                        purge pool row   purge match   clear cache       purge threads
+                                         rows (PR #119)                   (PR #119)
+```
+
+### 5.4 Admin resolve path
+
+```
+Admin UI ── PUT /reports/{id}/resolve { resolution } ──► Report Service
+                                                             │
+                                ┌────────────────────────────┤
+                                ▼                            ▼
+                       resolution ∈ { warning, dismiss } resolution == "ban"
+                       - update single row                - update single row
+                         to RESOLVED/DISMISSED              to RESOLVED
+                                                          - user.banned ──► cascade (§5.3)
+```
+
+---
+
+## 6. Cross-Service Dependencies
+
+| Caller | Target | Access | Why |
+|--------|--------|--------|-----|
+| Image Moderation | `shared.photos_bucket` | `s3:GetObject`, `s3:HeadObject` | Rekognition S3Object input; also used for HEAD checks |
+| Image Moderation | `kismet-photos` (D1 table) | `dynamodb:UpdateItem` (scoped ARN + `/index/*`) | set `status=rejected` on flag |
+| Text Moderation | AWS Comprehend | `comprehend:DetectToxicContent` | ML call |
+| Report Service | SES | `ses:SendEmail` | admin notification |
+| Report Service → D1 | via `user.banned` event | event-driven, no IAM grant | D1 Profile consumes, fans out |
+| Rate Limiter | ElastiCache Redis (VPC) | TCP 6379 via SG | counter store |
+
+D4 does not read from any other domain's DynamoDB table — all cross-domain effects flow through events. The one exception is the Image Moderation `UpdateItem` on `kismet-photos`, which was a deliberate decision (see Gotchas §7.3): adding a round-trip through a new `photo.rejected` event just to flip one attribute felt like overkill.
+
+---
+
+## 7. Known Gotchas / Postmortem Highlights
+
+1. **Handler name mismatch was silent (PR #115).** Both `text-moderation-service` and `image-moderation-service` originally defined `def lambda_handler(...)` while CDK wired `handler="lambda_function.handler"`. CloudFormation reported deploy success; every invocation failed with `Runtime.HandlerNotFound`. Fixed by renaming both to `def handler(...)` — matches the rest of the codebase. Worth a lint rule.
+2. **Rekognition only accepts JPEG / PNG.** WebP and HEIC (iPhone default) are rejected. The fix lives in the frontend: `frontend/src/lib/imageUtils.ts` re-encodes every upload to JPEG via a `<canvas>` before hitting S3. Document this as a D4 *input constraint* — if another upload path ever skips the canvas step (e.g., an admin import tool), moderation will 400 on those objects.
+3. **Rekognition S3 eventual consistency.** Freshly-uploaded S3 objects sometimes aren't visible to Rekognition for a few hundred ms, producing `InvalidS3ObjectException`. Today the handler raises `IMAGE_NOT_FOUND` on that code and relies on EventBridge's built-in retry window to bail us out. Tracked as a follow-up to add in-process 0.5s/1s/2s backoff — the EventBridge retry is 60 s, which is fine but noisy in logs. *(See Open Follow-ups.)*
+4. **`kismet-photos` cross-write creates a direction-of-authority question.** Image Moderation writes `status=rejected` on a table owned by D1 Photo. We accepted this because (a) moderation is the only external writer of `status=rejected`, (b) the IAM policy is narrowly scoped to the one table + its indexes, and (c) publishing a `photo.rejected` event just for D1 to loop back and update its own row doubles the latency. If another consumer ever needs the signal, revisit.
+5. **API Gateway stage auto-redeploy (#118).** Adding the `/reports` routes in a D4 deploy created the Resource but the `dev` stage had stale route definitions for about 10 minutes. Same class of bug as D2. No permanent fix yet.
+6. **Auto-ban is not atomic.** `_auto_ban_user` issues N `UpdateItem` calls in a loop, then a single `put_events`. If the Lambda dies mid-loop, some reports are marked RESOLVED but the `user.banned` event never fires — the ban effectively stalls. In practice N is small (threshold is 2) and the next report re-trips the threshold. A transactional resolve + event-outbox pattern is the right fix if this ever matters at scale.
+7. **Rate Limiter is admin-only today.** There is no public caller yet; the `check_rate_limit` function exists but no service imports it. Shipping the limits as a real middleware is blocked on the VPC-attachment question (every caller Lambda would need VPC config, which adds cold-start latency).
+
+---
+
+## 8. Open Follow-ups
+
+- **#118** — CDK: imported API Gateway stage auto-redeploy. Affects D4 route deploys.
+- **#120** — Ban notification email. Banned users currently have no idea why they got banned; they just find themselves gone from matches and unable to send messages. Add a `user.banned` consumer in D5 that emails the affected user the resolution/reason.
+- **#121** — Banned users can `DELETE /profiles/me` and re-register with the same email. `user.banned` doesn't block Cognito sign-up; D1 auth service doesn't consult a banlist. Simplest fix: a Dynamo banlist keyed on email hash, checked during sign-up.
+- **In-process Rekognition retry** (0.5s / 1s / 2s backoff on `InvalidS3ObjectException`) — planned but not yet in source. Would cut the noisy-logs case from §7.3 without waiting for EventBridge.
+- **Use `status-index` GSI** in `GET /reports?status=`. Currently implemented as a scan + FilterExpression; the GSI is declared in CDK but unused.
+- **Rate Limiter as shared middleware.** Either extract `check_rate_limit` into a Lambda Layer, or replace the Redis-direct pattern with an internal `POST /ratelimit/check` endpoint callable without VPC attachment. Blocked on how many callers actually need it.
+- **Admin UI for reports / moderation history** — the `GET /moderate/{text,image}/history` and `GET /reports?status=PENDING` endpoints exist but no frontend consumes them yet.
+
+---
+
+## 9. References
+
+- API contracts: [`docs/api-contracts/domain-4-text-moderation-service.md`](../api-contracts/domain-4-text-moderation-service.md), [`domain-4-image-moderation-service.md`](../api-contracts/domain-4-image-moderation-service.md), [`domain-4-report-service.md`](../api-contracts/domain-4-report-service.md), [`domain-4-rate-limiter-service.md`](../api-contracts/domain-4-rate-limiter-service.md)
+- Event shapes: [`event-schema.json`](./event-schema.json) — `message.sent`, `photo.uploaded`, `content.flagged`, `user.reported`, `user.banned`
+- Shared infra: [`shared_stack.py`](../../infra/stacks/shared_stack.py) (REST API, Cognito authorizer, `kismet-photos` bucket, event bus)
+- Reusable Lambda + DDB + route + IAM construct: [`kismet_constructs/kismet_service.py`](../../infra/kismet_constructs/kismet_service.py)
+- Cross-domain integration tests: [`tests/test_cross_domain_integration.py`](../../tests/test_cross_domain_integration.py)
+- Related PRs: #114 (auto-ban + `?status=` filter), #115 (handler name fix), #118 (stage redeploy), #119 (D2/D3 `profile.banned` purge), #120 (ban email — open), #121 (re-register loophole — open)

--- a/docs/system-design/Domain5_Design.md
+++ b/docs/system-design/Domain5_Design.md
@@ -1,0 +1,286 @@
+# Domain 5 — Notifications & Engagement
+
+> Detailed design for push, email, event-bus, and scheduler services.
+> Source of truth: [`infra/stacks/domain5_stack.py`](../../infra/stacks/domain5_stack.py) + [`services/domain-5-notifications/`](../../services/domain-5-notifications/)
+> Last verified: Apr 16, 2026
+
+---
+
+## 1. Purpose
+
+Domain 5 is the "engagement surface" of Kismet — it owns every piece of outbound communication (push, email), every timed job (digests, cleanups, health checks), and the cross-domain audit trail for events flowing through `kismet-events`. It runs four services, six Lambda functions, and four DynamoDB tables, backed by SNS platform endpoints, SES identities, and EventBridge Scheduler.
+
+Upstream, D5 is almost entirely event-driven: it consumes lifecycle events from D1 (Identity), match events from D2 (Discovery), message events from D3 (Messaging), and moderation events from D4. Downstream it publishes only `scheduler.*` events (from the scheduler executor) and re-publishes historical events on admin replay. The catch-all logger receives **every** `kismet.*` event on the bus and is the cross-cutting audit layer for the whole platform.
+
+---
+
+## 2. Architecture
+
+```
+                    ┌─────────────────────────────────┐
+                    │   Imported REST API + Cognito   │
+                    └──┬──────┬──────┬──────┬─────────┘
+                       │      │      │      │
+              ┌────────▼──┐ ┌─▼──┐ ┌─▼───┐ ┌▼──────────┐
+              │ Push Notif│ │Email│ │Event│ │Scheduler  │
+              │           │ │     │ │Admin│ │Admin      │
+              └──┬────┬───┘ └──┬──┘ └──┬──┘ └─────┬─────┘
+                 │    │        │       │          │
+             ┌───▼─┐ ┌▼───┐ ┌──▼─┐ ┌───▼─────┐ ┌──▼──────────┐
+             │ SNS │ │DDB │ │SES │ │DDB      │ │EventBridge  │
+             │     │ │×2  │ │    │ │event-log│ │Scheduler ×4 │
+             └─────┘ └────┘ └────┘ └──▲──────┘ └──────┬──────┘
+                                      │               │
+                               ┌──────┴──────┐  ┌─────▼──────┐
+                               │Catch-All Fn │  │Executor Fn │
+                               │(every kismet│  │(built-in + │
+                               │.* event)    │  │ custom jobs)│
+                               └──────▲──────┘  └─────┬──────┘
+                                      │               │
+                                      └───── kismet-events (EventBridge)
+                                              ▲
+                           in:  user.created, user.deleted, user.reported,
+                                match.created, message.sent
+                           out: scheduler.weekly_digest,
+                                scheduler.stale_match_cleanup,
+                                scheduler.analytics_aggregation,
+                                scheduler.health_check
+```
+
+See [`diagrams/domain5-architecture.drawio`](./diagrams/domain5-architecture.drawio).
+
+---
+
+## 3. Services
+
+### 3.1 Push Notification Service
+
+| | |
+|---|---|
+| **Entry** | `POST /notifications/register`, `GET /notifications`, `GET /notifications/unread-count`, `PUT /notifications/{notificationId}/read` (Cognito-authenticated) |
+| **Tables** | `kismet-notifications`, `kismet-device-tokens` (both PK/SK single-table) |
+| **Consumes events** | `match.created`, `message.sent` |
+| **Publishes** | none |
+
+**Responsibilities**
+1. Device registration: register FCM/APNS/web-push tokens with SNS `CreatePlatformEndpoint`, persist the returned `EndpointArn` keyed by `USER#{userId}` / `DEVICE#{deviceToken}`
+2. Fan-out on `match.created` — both matched users get an in-app notification row + a push to every registered device
+3. Fan-out on `message.sent` — only the `recipientId` (pulled from the event detail) gets notified; a 50-char preview is attached
+4. Serve in-app inbox (`GET /notifications`, paginated), mark-read, and O(1) unread-count lookups
+
+**Key design choices**
+- **Denormalized unread counter**: `UNREAD_COUNT` is a special SK on the user's partition updated via `ADD :1` / `ADD :-1`. Avoids a query-and-count on every `GET /unread-count`. Atomic DynamoDB `ADD` seeds the item on first write.
+- **Notification SK layout**: `NOTIF#{epoch_ms:013d}-{uuid8}`. The zero-padded epoch prefix gives chronological `ScanIndexForward=False` sort without client-side sort; the uuid suffix keeps concurrent writes collision-safe.
+- **Multi-platform SNS payload**: `MessageStructure="json"` with `default` / `GCM` / `APNS` branches in a single `Publish` call — one API call regardless of device mix.
+- **Graceful degradation**: if `sns.create_platform_endpoint` fails, the row is still written with an empty `snsEndpointArn`. The inbox works; only the push channel is disabled for that device.
+
+### 3.2 Email Service
+
+| | |
+|---|---|
+| **Entry** | `GET /email/preferences`, `PUT /email/preferences` |
+| **Table** | `kismet-email-preferences` (PK=`USER#{userId}`, SK=`PREFS`) |
+| **Consumes events** | `user.created`, `match.created`, `user.reported`, `user.deleted`, `scheduler.weekly_digest`, `message.sent` |
+| **Publishes** | none |
+
+Single Lambda handler (`lambda_function.handler`) dispatches on `source`+`detail-type` for EventBridge invocations and on `httpMethod`+`path` for API Gateway. Every outbound email goes through one helper (`send_ses_email`) that wraps `ses:SendEmail` with inline HTML + plaintext fallbacks.
+
+**Event handlers**
+
+| Event | Action |
+|-------|--------|
+| `user.created` | Insert preferences row with `DEFAULT_PREFERENCES` (all `True`) and the user's email, under `ConditionExpression: attribute_not_exists(PK)` so replays don't overwrite opt-outs. Then send the "welcome" template. |
+| `match.created` | For each userId in `detail.userIds`: read prefs, skip if `matchNotifications=False`, else render the "match_notification" template. |
+| `message.sent` | Read recipient's prefs, skip if `messageNotifications=False`, else send "message_notification". |
+| `user.reported` | Send "report_alert" template to `ADMIN_EMAIL` with the report/reporter/reportedUser/reason. No prefs check — admins don't opt out. |
+| `user.deleted` | `delete_item` on the preferences row. Irreversible. |
+| `scheduler.weekly_digest` | Paginated scan of the prefs table with `FilterExpression: weeklyDigest = True`, send the "weekly_digest" template to each. |
+
+**Email preferences**
+- Three boolean toggles: `matchNotifications`, `messageNotifications`, `weeklyDigest`. Defaulted to `True` for new users.
+- `GET /email/preferences` returns defaults if no row exists yet (first-read before `user.created` has landed).
+- `PUT /email/preferences` validates each field is `bool`, allowlists the three keys, and does a partial update — unlisted keys are preserved.
+- The user's email address is **cached on the prefs row** at `user.created` time. This is deliberate: it avoids a cross-domain read to D1's profile table on every match/message email.
+
+**SES sandbox constraints (critical)**
+- In the current AWS account SES is in sandbox mode: **both** the `Source` identity and **every** `Destination` address must be pre-verified in the SES console or the send throws `MessageRejected: Email address is not verified`.
+- Default `SENDER_EMAIL` in the stack is `noreply@kismet.app`, which is **not** verified. In the live demo environment the env var is overridden to `qinyuans0114@gmail.com`, which is verified. Any recipient used in a demo also has to be added to the verified-identity list first.
+- `send_ses_email` catches and logs SES exceptions rather than raising — a failed send won't block a downstream event handler from completing, but it will silently drop the email. Check CloudWatch for the Email Service log group when a demo recipient claims "I never got it."
+
+### 3.3 Event Bus Service
+
+| | |
+|---|---|
+| **Entry (admin)** | `GET /events/rules`, `GET /events/history?source&detailType&limit`, `POST /events/replay { eventId }` |
+| **Entry (event)** | EventBridge rule `kismet-catch-all-logger` — pattern `{source: [{prefix: "kismet."}]}` |
+| **Table** | `kismet-event-log` (PK=`EVENT#{eventId}`, SK=`META`, GSI `source-timestamp-index`) |
+| **Consumes events** | **every** `kismet.*` event on `kismet-events` |
+| **Publishes** | re-publishes originals on `/events/replay` |
+
+**What it actually does** — despite the "cross-domain event routing service" framing in the top-level Design Doc, the code is scoped more tightly:
+
+1. **Catch-all logger** (`catch_all_handler`) — target of a single EventBridge rule matching `source: prefix "kismet."`. Every event that hits the bus gets stored: eventId, source, detail-type, full detail JSON, timestamp, `status: "delivered"`. No routing, no forwarding — just the audit log.
+2. **Admin API** (`admin_api_handler`) — three endpoints for debugging:
+   - `/events/rules` lists live EventBridge rules + their targets (via `events:ListRules` + `events:ListTargetsByRule`), so you can verify a new consumer was wired correctly.
+   - `/events/history` queries the log. With `?source=` it uses the `source-timestamp-index` GSI for O(log n) by source; without, it falls back to a full `Scan` with a `Limit` cap at 100 (admin-only, low-traffic).
+   - `/events/replay` re-publishes a historical event back onto `kismet-events` using the original source + detail-type + detail, and writes a new log entry with `status: "replayed"` and `originalEventId` pointing back.
+
+Routing between producer and consumer is handled entirely by EventBridge rules defined in each domain's own CDK stack — Event Bus Service does **not** fan out, translate, or filter events. It is the observability + replay layer for the bus, not the routing layer.
+
+### 3.4 Scheduler Service
+
+| | |
+|---|---|
+| **Entry (admin)** | `GET /scheduler/jobs`, `POST /scheduler/jobs`, `DELETE /scheduler/jobs/{jobId}` |
+| **Entry (schedule)** | EventBridge Scheduler → `job_executor_handler` Lambda |
+| **Table** | `kismet-scheduler` (PK=`JOB#{jobId}`, SK=`META`) |
+| **Consumes events** | none (scheduler invocations are direct Lambda calls, not bus events) |
+| **Publishes** | `scheduler.weekly_digest`, `scheduler.stale_match_cleanup`, `scheduler.analytics_aggregation`, `scheduler.health_check` |
+
+Two Lambdas share the same code bundle:
+
+- **Job Executor** — invoked by EventBridge Scheduler with `{jobType, jobId?, params?}`. Looks up the job type in `JOB_EVENT_MAP` (the canonical registry of known job types) and emits the corresponding event onto `kismet-events`. If the invocation includes a `jobId` it updates `lastRunAt` on the DDB row; for built-in schedules `jobId` is `None` and the DDB write is skipped.
+- **Admin API** — CRUD over both the DDB registry and the `scheduler:*` API:
+  - `POST` creates an EventBridge Scheduler schedule (naming convention `kismet-{jobType}-{jobId}-{env}`), then writes the job row. Guards duplicates via a pre-scan on `jobType`+`schedule`.
+  - `DELETE` removes the schedule (tolerating `ResourceNotFoundException` if it's already gone), then deletes the row.
+
+**Built-in schedules** (created in the CDK stack, not via admin API — so they don't live in the DDB table):
+
+| ID | Cron / Rate | Job type | Fan-out |
+|----|-------------|----------|---------|
+| `WeeklyDigest` | `cron(0 9 ? * SUN *)` | `weekly_digest` | Email Service sends to users with `weeklyDigest=True` |
+| `StaleMatchCleanup` | `rate(1 day)` | `stale_match_cleanup` | (no consumer wired yet) |
+| `AnalyticsAggregation` | `rate(1 hour)` | `analytics_aggregation` | D6 Activity Logger flush (when Kinesis enabled) |
+| `HealthCheck` | `rate(5 minutes)` | `health_check` | D6 Health Monitor |
+
+> **Note**: the task brief described the weekly digest as "Scheduler → Step Functions → Email." There are no Step Functions in the stack. The actual path is **EventBridge Scheduler (cron) → Executor Lambda → `put_events` onto kismet-events → Email Service catch-handler**. A Step Function would be overkill here — the work is one scan + one SES send per user and fits within a single Lambda's timeout for the current user base.
+
+---
+
+## 4. Data Layer
+
+| Table | Primary key | GSI | Notes |
+|-------|-------------|-----|-------|
+| `kismet-notifications` | `USER#{userId}` / `NOTIF#{epoch_ms}-{uuid8}` or `UNREAD_COUNT` | — | in-app inbox + atomic unread counter; read paged newest-first |
+| `kismet-device-tokens` | `USER#{userId}` / `DEVICE#{deviceToken}` | — | one row per registered device; stores `snsEndpointArn` |
+| `kismet-email-preferences` | `USER#{userId}` / `PREFS` | — | three opt-in booleans + cached email for event handlers |
+| `kismet-event-log` | `EVENT#{eventId}` / `META` | `source-timestamp-index` (source HK, timestamp RK) | every bus event, queryable by source |
+| `kismet-scheduler` | `JOB#{jobId}` / `META` | — | custom (admin-created) jobs only; built-ins live in CFN |
+
+All tables are `PAY_PER_REQUEST` with `RemovalPolicy.DESTROY` — acceptable for a demo environment, would flip to `RETAIN` before any real launch.
+
+---
+
+## 5. Event Flows
+
+### 5.1 New user → welcome email + prefs row
+
+```
+D1 Profile Service
+    │
+    └─── user.created ──► EventBridge
+                              │
+                              ▼
+                       Email Service
+                       - conditional put on prefs row (idempotent)
+                       - ses:SendEmail "welcome"
+```
+
+### 5.2 Match created → push + email to both users
+
+```
+D2 Match Service ── match.created ──► EventBridge
+                                           │
+                        ┌──────────────────┼─────────────────────┐
+                        ▼                  ▼                     ▼
+                Push Notif Service    Email Service         Catch-All Logger
+                - for each userId:    - for each userId:    - put to event-log
+                    create notif row      read prefs.match
+                    ADD unread_count       skip if opted-out
+                    SNS publish × N        ses:SendEmail
+                    devices
+```
+
+### 5.3 Weekly digest
+
+```
+EventBridge Scheduler (cron SUN 09:00 UTC)
+    │
+    ▼
+Scheduler Executor Lambda
+    │
+    └─── scheduler.weekly_digest ──► EventBridge
+                                          │
+                             ┌────────────┴────────────┐
+                             ▼                         ▼
+                       Email Service              Catch-All Logger
+                       - paginated scan            - log event
+                         where weeklyDigest=True
+                       - ses:SendEmail × N
+```
+
+### 5.4 Account deletion
+
+```
+D1 Profile Service
+    │
+    └─── user.deleted ──► EventBridge
+                              │
+                              ▼
+                       Email Service
+                       - delete prefs row
+    (Push Notif does NOT currently handle user.deleted — notification
+     rows and device tokens are orphaned until TTL / manual cleanup.
+     See §7 gotchas.)
+```
+
+---
+
+## 6. Cross-Service Dependencies
+
+| Caller | Reads / Writes | Why |
+|--------|----------------|-----|
+| Email Service | reads `kismet-email-preferences` (own); `email` attribute cached on row | avoid cross-domain read to D1 profile on every email |
+| Push Notif | reads `kismet-device-tokens`, writes `kismet-notifications` | fan-out + inbox |
+| Event Bus (catch-all) | writes `kismet-event-log` only | audit trail |
+| Event Bus (admin) | reads `kismet-event-log`, reads EventBridge rules, puts to `kismet-events` on replay | debugging |
+| Scheduler (executor) | puts to `kismet-events`, updates `kismet-scheduler.lastRunAt` | timed trigger |
+| Scheduler (admin) | CRUD on `scheduler:*` + `kismet-scheduler`; `iam:PassRole` on `kismet-scheduler-execution-role` | custom-job registration |
+
+No D5 service writes into another domain's table. All cross-domain signalling is via EventBridge.
+
+---
+
+## 7. Known Gotchas / Postmortem Highlights
+
+1. **SES sandbox** — the #1 support request from demo rehearsals. Both sender and recipient must be verified in the AWS account running the demo. `SENDER_EMAIL` defaults to the unverified `noreply@kismet.app`; override via the Lambda env var to a verified identity (today: `qinyuans0114@gmail.com`). Sends fail with `MessageRejected: Email address is not verified` in CloudWatch.
+2. **#120 — no ban notification email.** Email Service's consumer list does **not** include `profile.banned`. When a user is banned via D4 moderation, no email is sent to explain the action. Follow-up: add `profile.banned` to the CDK `consume_events` list and wire a handler that sends from a verified admin identity even if the user's own address isn't verified (relevant because banned users may not be on the verified list).
+3. **Stale device tokens.** SNS raises `EndpointDisabled` for tokens that APNs/FCM has invalidated. `send_push_to_user` currently catches the exception and logs it, but does **not** delete the row from `kismet-device-tokens`. Over time this produces repeated publish attempts against dead endpoints. Follow-up: detect `EndpointDisabled` specifically and `delete_item` the offending `DEVICE#` row.
+4. **`user.deleted` doesn't purge push state.** Email Service deletes the prefs row; Push Notif Service has no `user.deleted` handler. Notification rows and device-token rows for a deleted user are orphaned until we add a purge or a TTL attribute on the tables.
+5. **Kinesis fallback.** The `analytics_aggregation` schedule fires every hour, but in the current AWS account Kinesis is disabled per Shared Stack config, so D6 Activity Logger silently drops the event. The scheduler run still succeeds — no alarm.
+6. **"Cross-domain event routing service" is a misnomer.** The top-level Design Doc §3 describes Event Bus Service as doing routing; the code does audit logging + replay only. EventBridge rules in each domain's stack do the actual routing. This design doc reflects the code; the top-level doc should be corrected.
+7. **`events:ListRules` IAM scope.** The admin Lambda's IAM policy grants `events:ListRules` scoped to `rule/kismet-events/*`. `ListRules` requires `EventBusName` to be supplied in the SDK call; if you call it bare it targets `default` and returns nothing — easy to misdiagnose as "no rules exist."
+8. **Replay is idempotent-unsafe.** `POST /events/replay` re-emits the original event with a new EventBridge `id`. Every downstream consumer will re-run its handler. For `match.created` that means a duplicate notification row + duplicate email. Use with care; not safe to replay `user.created`.
+9. **Unread-count drift.** The counter is updated separately from the notification row put. If the put succeeds and the counter `update_item` fails (ops error, throttle), the counter drifts low. No reconciliation job exists. Low-priority because DDB on-demand rarely throttles at demo scale.
+
+---
+
+## 8. Open Follow-ups
+
+- **#120** — Ban notification email (consume `profile.banned`, use verified admin sender)
+- Handle `EndpointDisabled` in Push Notif and delete the stale token row
+- Add `user.deleted` handler to Push Notif to purge notifications + device tokens
+- TTL attribute on `kismet-notifications` so read notifications age out automatically
+- Wire a consumer for `scheduler.stale_match_cleanup` (currently fires to a black hole every day)
+- Correct Event Bus Service description in the top-level Design Doc §3 to match the code
+- Reconciliation job for `UNREAD_COUNT` drift (low priority)
+
+---
+
+## 9. References
+
+- API contracts: [`docs/api-contracts/domain-5-*.md`](../api-contracts/)
+- Event shapes: [`event-schema.json`](./event-schema.json)
+- Shared infra: [`shared_stack.py`](../../infra/stacks/shared_stack.py)
+- Reusable Lambda + DDB + route + IAM construct: [`kismet_constructs/kismet_service.py`](../../infra/kismet_constructs/kismet_service.py)
+- Top-level architecture: [`Design_Doc.md`](./Design_Doc.md)

--- a/docs/system-design/Domain6_Design.md
+++ b/docs/system-design/Domain6_Design.md
@@ -1,0 +1,335 @@
+# Domain 6 — Analytics & Admin
+
+> Detailed design for the activity-log, analytics pipeline, admin dashboard, and health-monitor services.
+> Source of truth: [`infra/stacks/domain6_stack.py`](../../infra/stacks/domain6_stack.py) + [`services/domain-6-analytics/`](../../services/domain-6-analytics/)
+> Last verified: Apr 16, 2026
+
+---
+
+## 1. Purpose
+
+Domain 6 is Kismet's **observability and operator surface**. Nothing in the user-facing product calls D6 directly — instead, it's the fan-in sink for every interesting event that happens elsewhere, plus the back-office console for operators to see what's going on and act on it.
+
+It owns four Lambda services backed by three DynamoDB tables, one S3 bucket, one Athena database, and one SNS topic. Upstream, it consumes virtually every domain event on the `kismet-events` bus — D1's user/profile lifecycle, D2's swipes and matches, D3's messages, D4's moderation events. Downstream, it publishes **nothing** back to EventBridge; its outputs are HTTP responses (admin console, health probes) and SNS alerts.
+
+---
+
+## 2. Architecture
+
+See [`diagrams/domain6-architecture.drawio`](./diagrams/domain6-architecture.drawio).
+
+```
+     ┌───────────────────────────── kismet-events (EventBridge) ───────────────────────────┐
+     │                                                                                     │
+     │  user.created, profile.completed, swipe.created, match.created, message.sent,       │
+     │  photo.uploaded, content.flagged, user.reported                                     │
+     │                                                                                     │
+     └───────┬─────────────────────────────────────────────────────────┬───────────────────┘
+             │                                                         │
+             ▼                                                         ▼
+      ┌──────────────┐                                          ┌──────────────┐
+      │  Activity    │                                          │    Admin     │
+      │  Logger      │──► kismet-activity-log (DDB)             │  Dashboard   │──► kismet-flagged-content
+      │              │──► (Kinesis put_record — disabled,       │              │──► kismet-admin-stats
+      │              │     failure is swallowed, see §3.1)      │              │──► kismet-profiles (x-domain)
+      └──────────────┘                                          └──────┬───────┘
+             │                                                         │
+             ▼ (intended; currently inert)                              │ REST /admin/*
+       ┌───────────┐        ┌──────────────┐         ┌──────────┐      │
+       │  Kinesis  │──────► │   Firehose   │────────►│    S3    │      ▼
+       │  Stream   │        │              │         │ analytics│  ┌──────────────┐
+       └───────────┘        └──────────────┘         └────┬─────┘  │   Admin UI   │
+                                                          │        └──────────────┘
+                                                          ▼
+                                                     ┌─────────┐
+                                                     │ Athena  │◄── Analytics Pipeline
+                                                     └─────────┘    (POST /analytics/query,
+                                                                     GET  /analytics/dashboard)
+
+      ┌───────────────┐   CloudWatch GetMetricData   ┌──────────────────┐
+      │ Health Monitor│─────────────────────────────►│ AWS/Lambda       │
+      │               │──► SNS: kismet-health-alerts │   metrics (per   │
+      │               │──► kismet-health-history     │   kismet-* fn)   │
+      └───────────────┘                              └──────────────────┘
+
+    EventBridge: kismet-events
+      in (Activity Logger):  user.created, profile.completed, swipe.created, match.created,
+                             message.sent, photo.uploaded, content.flagged, user.reported
+      in (Admin Dashboard):  content.flagged, user.reported
+      out: (none — D6 is a sink)
+```
+
+---
+
+## 3. Services
+
+### 3.1 Activity Logger Service
+
+| | |
+|---|---|
+| **Entry** | `POST /analytics/log` (no auth — trusted intra-VPC ingest), `GET /analytics/log/recent?userId&eventType&limit` (auth) |
+| **Table** | `kismet-activity-log` (PK=`USER#{userId}`, SK=`EVENT#{timestamp}#{logId}`) |
+| **Consumes events** | `swipe.created`, `match.created`, `message.sent`, `user.created`, `profile.completed`, `photo.uploaded`, `content.flagged`, `user.reported` |
+| **Publishes** | none |
+
+**Responsibilities**
+1. Fan-in sink for cross-domain events — every interesting thing that happens in D1-D5 lands here
+2. Per-user activity timeline (query by `USER#{userId}`, sorted newest-first via `ScanIndexForward: False`)
+3. Originally designed to feed a Kinesis Data Stream for real-time analytics; **currently writes directly to DynamoDB** (see Kinesis caveat below)
+
+**Key design choices**
+- **Per-user partitioning**: `PK=USER#{userId}` means one user's timeline is a single DDB partition, efficient for the recent-activity read. The trade-off is that cross-user analytical queries require a full scan (which is what Analytics Pipeline / Athena is for, on the S3 side).
+- **`_extract_user_id` normalizes heterogeneous event shapes**: `match.created` carries `userIds[]` (we pick index 0 and write a *second* row for `userIds[1]` so both users' timelines see the match); `message.sent` uses `senderId`; `user.reported` uses `reporterId`; everything else falls back to `detail.userId`. See `lambda_function.py:48-57`.
+- **Unauthenticated `POST /analytics/log`**: intentionally open because it's the manual/legacy ingestion path for events that don't flow through EventBridge yet. Not public-exposed — meant to be called by other Lambdas inside the account.
+
+**Kinesis fallback (current reality).** `SharedStack.activity_stream = None` in the current AWS account because Kinesis is not yet provisioned (see `shared_stack.py:127-136`). The CDK stack correspondingly has the Kinesis import commented out (`domain6_stack.py:30-35`) and does **not** pass `KINESIS_STREAM_NAME` into the Lambda env. The Lambda code still calls `kinesis.put_record(...)` on every event, wrapped in a bare `try/except` that swallows the failure and logs it (`lambda_function.py:195-203`). The net effect:
+
+1. Every event still lands in `kismet-activity-log` via `_write_to_dynamodb` — **DDB is effectively the current system of record for activity**.
+2. Every event also triggers a failing Kinesis call, logging a line per invocation. Noisy but harmless.
+3. Analytics Pipeline's S3/Athena path is therefore **empty** until Kinesis + Firehose are re-enabled — see §3.2.
+
+### 3.2 Analytics Pipeline Service
+
+| | |
+|---|---|
+| **Entry** | `POST /analytics/query { sql }`, `GET /analytics/query/{queryId}`, `GET /analytics/dashboard` (all auth) |
+| **Table** | none (Athena over S3) |
+| **Consumes events** | none |
+| **Publishes** | none |
+
+**Intended pipeline**: Kinesis Data Stream (`kismet-activity-stream`) → Firehose → S3 (`kismet-analytics-{account}-dev`, prefix `events/`) → Athena external table `kismet_analytics.activity_events`.
+
+**Current pipeline**: Kinesis is disabled (see §3.1). Firehose is not provisioned. The S3 bucket exists and is empty. Athena queries succeed but return zero rows.
+
+**Athena catalog bootstrap** — `_ensure_catalog()` lazily (once per cold start, guarded by the module-level `_catalog_ready` flag) runs:
+
+```sql
+CREATE DATABASE IF NOT EXISTS kismet_analytics;
+CREATE EXTERNAL TABLE IF NOT EXISTS kismet_analytics.activity_events (
+  logId STRING, eventType STRING, userId STRING,
+  eventData STRING, source STRING, `timestamp` STRING
+)
+ROW FORMAT SERDE 'org.openx.data.jsonserde.JsonSerDe'
+WITH SERDEPROPERTIES ('ignore.malformed.json' = 'true')
+LOCATION 's3://kismet-analytics-{account}-dev/events/';
+```
+
+Note: **no partitioning** defined on the external table. If the pipeline is re-enabled with any meaningful volume, partitioning by date (`events/year=YYYY/month=MM/day=DD/…`) will be needed to keep scan cost bounded — an open follow-up.
+
+**Query lifecycle**:
+- `POST /analytics/query` calls `athena:StartQueryExecution` and returns a `queryExecutionId` immediately (async).
+- `GET /analytics/query/{queryId}` polls `GetQueryExecution` + `GetQueryResults` when state is `SUCCEEDED`.
+- `GET /analytics/dashboard` runs a **synchronous** canned query with up to 25 s of 1 s polling (`_run_query_sync`) — DAU, totalUsers, matchesToday, messagesToday. Returns zeros on any Athena failure so the console doesn't break.
+
+**IAM scope**: Athena, S3 read/write on the analytics bucket only, Glue catalog read/write. No DDB access.
+
+### 3.3 Admin Dashboard Service
+
+| | |
+|---|---|
+| **Entry** | 6 routes under `/admin/*` — see table below, all auth |
+| **Tables** | `kismet-admin-stats` (stat counters), `kismet-flagged-content` (moderation queue), reads/writes `kismet-profiles` (D1-owned, cross-domain) |
+| **Consumes events** | `content.flagged`, `user.reported` |
+| **Publishes** | none |
+
+| Route | Purpose |
+|-------|---------|
+| `GET /admin/stats` | Batch-read 5 counters (totalUsers, activeUsers, matchesToday, messagesToday, flaggedContentCount) from `kismet-admin-stats` at `STAT#{name}`/`LATEST` |
+| `GET /admin/flagged-content` | Scan `kismet-flagged-content`, optional `?type=text|image`, cursor pagination |
+| `PUT /admin/flagged-content/{contentId}/resolve` | Action = `approve` / `remove` / `ban_user`; `ban_user` cascades into `kismet-profiles` |
+| `GET /admin/users` | Scan `kismet-profiles` filtered to `SK=PROFILE`, optional `search` (substring on `name`) |
+| `PUT /admin/users/{userId}/ban` | Admin-initiated ban — sets `status=banned`, `bannedBy`, `bannedAt` on D1's profile row |
+| `PUT /admin/users/{userId}/unban` | Reverse the above |
+
+**Cross-domain write** — this is the only D6 service that writes outside its own tables. `domain6_stack.py:186-196` explicitly grants `GetItem/UpdateItem/Scan` on `kismet-profiles` for ban/unban/search. The ban does **not** publish `profile.banned` itself; it updates the `status` field directly. D1's Profile Service is expected to be the one publishing that event — if the admin ban path doesn't go through D1, **downstream consumers of `profile.banned` (Discovery, Match, Message) will miss the admin-initiated ban**. Tracked as a gotcha in §7.
+
+**Admin-only authentication — demo-only**. Every `/admin/*` route is declared `auth: True` in CDK, which wires the shared Cognito authorizer. **The Lambda itself does no role check** — `_get_admin_id` reads `claims.sub` but never inspects a group or `custom:role` claim. So any authenticated user can call every `/admin/*` endpoint. The API contract (`domain-6-admin-dashboard-service.md`) documents `403 FORBIDDEN — Not an admin`, but that response path is not implemented. For production this needs either:
+- API Gateway authorizer changes to require a Cognito group (e.g. `admins`), or
+- An in-Lambda check on `claims['cognito:groups']` or `claims['custom:role']`.
+
+For the course demo the model is "whoever knows the admin UI URL is an admin". Explicit and documented, not accidental.
+
+**Event handlers**:
+- `content.flagged` (from D4 Image Moderation / Text Moderation) → writes a row to `kismet-flagged-content` with `status=pending` and increments `flaggedContentCount`.
+- `user.reported` (from D4 Report Service) → increments `reportCount` on the reported user's profile row. Does **not** auto-ban — that's D4's 2-distinct-reports policy.
+
+**Missing integrations (known):**
+- Does **not** consume `profile.banned`. When D4/D1 auto-ban from a 2nd distinct report, the admin dashboard has no record of it — the user just silently appears with `status=banned` on the next `/admin/users` scan. Auto-bans should ideally publish into the flagged-content queue for audit visibility.
+- The `?status=PENDING` report filter added in #114 is **not wired** into `GET /admin/flagged-content`. The handler always scans all rows regardless of status. Low-effort fix.
+
+### 3.4 Health Monitor Service
+
+| | |
+|---|---|
+| **Entry** | `GET /health` (public, no auth), `GET /health/{serviceName}`, `GET /health/alarms`, `POST /health/check` (auth) |
+| **Table** | `kismet-health-history` (PK=`SERVICE#_all`, SK=`CHECK#{timestamp}`) |
+| **Consumes events** | none |
+| **Publishes** | SNS only (`kismet-health-alerts`) |
+
+**Monitored services** — hardcoded in `KNOWN_SERVICES`:
+
+```
+auth-service, profile-service, swipe-service, match-service,
+message-service, chat-gateway
+```
+
+Conspicuous absence: D4 moderation services, D5 notification services, and the D6 services themselves. The list reflects the "core user path" — if these six are healthy, a user can sign in, browse, swipe, match, and chat. Expanding it is just editing the constant.
+
+**Metric derivation** — for each service, `cloudwatch:GetMetricData` pulls a 5-minute window of `AWS/Lambda` metrics: `Errors` (Sum), `Invocations` (Sum), `Duration` (Average + p99), `Throttles` (Sum). Status classification:
+
+| Status | Condition |
+|--------|-----------|
+| `unhealthy` | `errorRate > 0.05` |
+| `degraded` | `avgDuration > 300 ms` |
+| `healthy` | otherwise |
+
+Overall status is the **worst** of the per-service statuses (`_rollup_status`).
+
+**Two read paths, one write path**:
+- `GET /health` and `GET /health/{serviceName}` are **pure reads** — compute-on-demand from CloudWatch, no DDB write. Public `/health` is safe because it returns only statuses and average latency, not raw invocation counts.
+- `POST /health/check` is the **canonical sampler**: same rollup, plus it writes a history row to `kismet-health-history` and — if overall status is not `healthy` — publishes to the `kismet-health-alerts` SNS topic. Intended to be hit on a schedule (EventBridge rule or external cron; not currently wired in CDK).
+- `GET /health/alarms` calls `cloudwatch:DescribeAlarms(StateValue=ALARM)` and returns anything currently firing, stripping the `-error-rate` naming suffix to surface the service name.
+
+**SNS alert shape**:
+
+```json
+{
+  "alarmName": "kismet-system-health",
+  "serviceName": "_all",
+  "state": "DEGRADED" | "UNHEALTHY",
+  "reason": "Degraded/unhealthy services: swipe-service, match-service",
+  "timestamp": "2026-04-16T..."
+}
+```
+
+No actual CloudWatch Alarms are defined in `domain6_stack.py` — alarm discovery is read-only. If the team wants real alarms (with auto-SNS on threshold breach), those need to be added as `cloudwatch.Alarm` constructs in whichever stack owns the metric.
+
+---
+
+## 4. Data Layer
+
+| Table | Primary key | Size profile | Notes |
+|-------|-------------|--------------|-------|
+| `kismet-activity-log` | PK `USER#{userId}` / SK `EVENT#{timestamp}#{logId}` | 1 row per event per user (2 per match) | Grows linearly with activity; TTL not set — future follow-up |
+| `kismet-admin-stats` | PK `STAT#{statName}` / SK `LATEST` | ~5 rows, one per tracked counter | Atomic `ADD :delta` updates; stored as numbers |
+| `kismet-flagged-content` | PK `CONTENT#{contentId}` / SK `META` | Bounded by moderation volume | Confidence stored as `Decimal` to avoid float drift |
+| `kismet-health-history` | PK `SERVICE#_all` / SK `CHECK#{timestamp}` | 1 row per `POST /health/check` | All checks stored under one partition — fine at current sample rate (minutes), would need per-service PK at high frequency |
+| `kismet-profiles` *(D1-owned, cross-domain)* | PK `USER#{userId}` / SK `PROFILE` | — | Admin Dashboard reads and writes `status`/`bannedBy`/`bannedAt`/`reportCount` |
+
+All tables use on-demand billing. No GSIs.
+
+**S3**: `kismet-analytics-{account}-dev` — analytics data (`events/` prefix) + Athena query results (`athena-results/` prefix). `auto_delete_objects=True` and `RemovalPolicy.DESTROY` — demo-safe, not production.
+
+---
+
+## 5. Event Flows
+
+### 5.1 Swipe → Activity Log
+
+```
+D2 Swipe Service ── swipe.created ──► EventBridge
+                                          │
+                                          ▼
+                                 Activity Logger
+                                 - put 1 row at USER#{swiperId}
+                                 - (Kinesis put fails silently)
+```
+
+### 5.2 Match → Both Users' Timelines
+
+```
+D2 Match Service ── match.created {userIds: [A, B]} ──► EventBridge
+                                                           │
+                                                           ▼
+                                                 Activity Logger
+                                                 - put row at USER#A (index 0)
+                                                 - put row at USER#B (index 1)
+```
+
+See `lambda_function.py:85-93` — `match.created` is the one event that fans to two DDB rows so both participants' activity feeds reflect it.
+
+### 5.3 Content Flagged → Admin Queue
+
+```
+D4 Image/Text Moderation ── content.flagged ──► EventBridge
+                                                   │
+                                     ┌─────────────┴─────────────┐
+                                     ▼                           ▼
+                            Activity Logger              Admin Dashboard
+                            - timeline row               - put CONTENT# row
+                                                         - flaggedContentCount++
+
+Admin opens dashboard ──► GET /admin/flagged-content
+Admin clicks "Ban"    ──► PUT /admin/flagged-content/{id}/resolve {action: "ban_user"}
+                            - update CONTENT# status=resolved
+                            - update kismet-profiles status=banned   ⚠ no event published
+                            - flaggedContentCount--
+```
+
+The ⚠ note on the last step: downstream domains only learn about the ban if D1 or D4 publishes `profile.banned` elsewhere. D6's direct profile write is a shortcut that bypasses the event system — acceptable for demo, a gotcha for production.
+
+### 5.4 Health Check Cycle
+
+```
+(scheduled trigger — currently manual or via console)
+          │
+          ▼
+   POST /health/check
+          │
+          ├──► CloudWatch GetMetricData × 6 services × 5 metrics
+          ├──► kismet-health-history put_item
+          └──► if !healthy: SNS publish to kismet-health-alerts
+```
+
+---
+
+## 6. Cross-Service Dependencies
+
+| Caller | Reads/writes | Why |
+|--------|--------------|-----|
+| Activity Logger | writes `kismet-activity-log` only | Pure sink |
+| Analytics Pipeline | reads/writes `kismet-analytics-*` S3, Athena, Glue | No DDB |
+| Admin Dashboard | writes `kismet-profiles` (D1-owned) | Ban / unban path |
+| Admin Dashboard | reads `kismet-profiles` | User list and search |
+| Health Monitor | reads CloudWatch metrics for every `kismet-*` Lambda | Cross-cutting |
+
+Nobody else writes D6's tables — the fan-in is one-way via EventBridge.
+
+---
+
+## 7. Known Gotchas / Postmortem Highlights
+
+1. **Kinesis is disabled on the current AWS account.** `SharedStack.activity_stream = None` (`shared_stack.py:127-136`). The Activity Logger Lambda still issues `kinesis.put_record` on every invocation, wrapped in try/except — one noisy log line per event, no correctness impact. The Analytics Pipeline's S3/Athena path is consequently empty and the `/analytics/dashboard` endpoint returns zeros. DynamoDB (`kismet-activity-log`) is the de-facto system of record until the stream comes back.
+2. **Admin auth is demo-only.** `auth: True` on `/admin/*` only means "valid Cognito JWT required". The Lambda does not check group membership or `custom:role`. Any signed-in user can ban other users. Documented in `domain-6-admin-dashboard-service.md` as `403 FORBIDDEN`, but that branch does not exist in code. Fix = authorizer-level group check OR in-Lambda claim inspection.
+3. **Admin ban doesn't fan out.** `PUT /admin/users/{id}/ban` and the `ban_user` resolve action update `kismet-profiles.status` directly but do **not** publish `profile.banned`. Other domains (D2 Discovery, Match, D3 Message) rely on that event to purge state — they won't see an admin ban unless D1 Profile Service re-publishes the event itself. Course-correct is either publishing from the admin path or routing the write through D1.
+4. **Admin Dashboard doesn't consume `profile.banned`.** Auto-bans from D4's "2 distinct reports" policy silently flip a profile's status; the admin console has no audit row for them. Adding `profile.banned` to `consume_events` and writing an entry into `kismet-flagged-content` (or a dedicated audit table) would close this loop.
+5. **`?status=PENDING` filter from #114 isn't wired.** The report-queue filter landed in D4 but `GET /admin/flagged-content` still scans all rows. Trivial follow-up.
+6. **No partitioning on the Athena external table.** `activity_events` is flat at `events/` with no date partitions. Fine at current (zero) volume; a ticking time bomb once the Kinesis/Firehose path is active. Firehose should be configured with dynamic partitioning or at minimum year/month/day prefixing.
+7. **`kismet-health-history` single-partition.** All health checks write `PK=SERVICE#_all`, which is fine at a per-minute sample rate but would hot-spot at higher frequencies. Splitting to `PK=SERVICE#{name}` keeps per-service history queryable and distributes writes.
+8. **`KNOWN_SERVICES` is hardcoded.** Health Monitor only watches six services; D4/D5/D6 Lambdas are invisible to `/health`. Editing the list is a one-line change but there's no convention forcing it to stay in sync with CDK.
+9. **No CloudWatch Alarms are provisioned.** `/health/alarms` reads alarms but the stack doesn't create any. Real proactive alerting requires adding `cloudwatch.Alarm` constructs alongside the metrics they watch.
+
+---
+
+## 8. Open Follow-ups
+
+- Re-enable Kinesis + Firehose once AWS account limits allow; re-wire `KINESIS_STREAM_NAME` env var and verify S3 partitioning.
+- Admin role check — either Cognito group `admins` enforced at the authorizer, or explicit claim check in the Lambda.
+- Publish `profile.banned` from admin ban paths (or route through D1).
+- Consume `profile.banned` in Admin Dashboard for auto-ban audit trail.
+- Wire `?status=pending` filter on `GET /admin/flagged-content` (#114 follow-on).
+- Add date partitioning to the Athena external table.
+- Schedule `POST /health/check` via EventBridge rule (every 1-5 min).
+- Provision real `cloudwatch.Alarm`s for the 6 core services → SNS → PagerDuty/email.
+- TTL on `kismet-activity-log` to bound storage cost.
+- Expand `KNOWN_SERVICES` in Health Monitor to cover D4/D5/D6.
+
+---
+
+## 9. References
+
+- API contracts: [`docs/api-contracts/domain-6-*.md`](../api-contracts/)
+- Event shapes: [`event-schema.json`](./event-schema.json)
+- Shared infra: [`shared_stack.py`](../../infra/stacks/shared_stack.py) (Kinesis disabled at line 136, analytics bucket at 119, SNS topic at 140)
+- Reusable Lambda + DDB + route + IAM construct: [`kismet_constructs/kismet_service.py`](../../infra/kismet_constructs/kismet_service.py)
+- Cross-domain integration tests: [`tests/test_cross_domain_integration.py`](../../tests/test_cross_domain_integration.py)

--- a/docs/system-design/SharedStack_Design.md
+++ b/docs/system-design/SharedStack_Design.md
@@ -1,0 +1,256 @@
+# SharedStack — Cross-Domain Foundation
+
+> Detailed design for the single PM-owned CDK stack that every Kismet domain depends on.
+> Source of truth: [`infra/stacks/shared_stack.py`](../../infra/stacks/shared_stack.py) + [`infra/app.py`](../../infra/app.py)
+> Last verified: Apr 16, 2026
+
+---
+
+## 1. Purpose
+
+`SharedStack` is the single foundational stack deployed **once, by the PM**, before any domain team runs `cdk deploy`. It exists so that the six domain stacks (D1 Identity, D2 Discovery, D3 Messaging, D4 Moderation, D5 Notifications, D6 Analytics) don't each spin up their own Cognito pool, REST API, event bus, or photo bucket — instead they all wire into the same "facility-level" resources.
+
+Keeping these resources in one stack has two practical effects:
+1. **One auth plane, one API host, one event bus.** The frontend has a single Cognito user pool ID and a single `/dev` API URL to bind to. Events published by D2 are visible to D3/D5/D6 without any cross-bus routing.
+2. **One blast radius, one owner.** Anything cross-cutting (CORS, authorizer, photo CDN) changes in one place. Domain teams never touch Shared without PM review.
+
+The trade-off — and the source of most of the gotchas in §5 — is that every domain stack becomes a **consumer of Shared's CloudFormation exports**, which makes updating Shared after the fact harder than updating a domain.
+
+---
+
+## 2. Architecture
+
+```
+                     ┌──────────────────────────────────┐
+                     │           SharedStack            │
+                     │                                  │
+   Cognito UserPool ─┤  kismet-user-pool  ──► Authorizer│─┐
+   (self sign-up)    │                                  │ │
+                     │  API Gateway  kismet-api / dev ──┼─┼──► domain stacks
+                     │                                  │ │    attach routes
+   EventBridge ──────┤  kismet-events bus  ─────────────┼─┼──► publishers + rules
+                     │                                  │ │
+   S3 photos ────────┤  kismet-photos-{acct}-dev  ──┐   │ │
+                     │                              ▼   │ │
+                     │  CloudFront (HTTPS, gzip, cached)│─┴─► Photo Service (D1)
+                     │                                  │
+   S3 analytics ─────┤  kismet-analytics-{acct}-dev     │──► D6 / analytics jobs
+                     │                                  │
+   Kinesis ──────────┤  DISABLED (self.activity_stream  │    D6 falls back to
+                     │   = None — see §5.1)             │    direct-write
+                     │                                  │
+   SNS ──────────────┤  kismet-health-alerts            │──► Health Monitor
+                     └──────────────────────────────────┘
+```
+
+`app.py` instantiates `SharedStack` first, then passes the reference into every domain: `DomainNStack(app, "KismetDomainN", shared=shared, env=env)`.
+
+---
+
+## 3. Resources Deep-Dive
+
+### 3.1 Cognito UserPool — `kismet-user-pool`
+
+| | |
+|---|---|
+| **Construct ID** | `UserPool` |
+| **Sign-in** | email alias |
+| **Self sign-up** | enabled |
+| **Auto-verify** | email |
+| **Password policy** | min length 8, uppercase not required, symbols not required |
+| **Removal policy** | `DESTROY` |
+
+Self sign-up is on because the demo flow has users register themselves from the web client — there is no invite gate. Auto-verify on email is what lets Cognito send the confirmation code without an admin step.
+
+The relaxed password policy (no uppercase, no symbols) is a deliberate demo-only choice: it keeps the barrier low for reviewers creating throwaway accounts. Production would tighten this.
+
+`RemovalPolicy.DESTROY` means `cdk destroy KismetShared` will take the user pool with it — fine for a teardown-capable demo account, not fine for anything with real users.
+
+### 3.2 Cognito App Client — `kismet-web-client`
+
+Attached to the user pool via `user_pool.add_client(...)`. Auth flows enabled:
+- `USER_PASSWORD_AUTH` — used by the web client's login form (username+password direct)
+- `USER_SRP_AUTH` — used by Amplify/`amazon-cognito-identity-js` when it chooses SRP
+
+Both are enabled so the frontend library is free to pick either. No client secret is configured (this is a public SPA client).
+
+### 3.3 API Gateway REST API — `kismet-api`
+
+| | |
+|---|---|
+| **Construct ID** | `Api` |
+| **Type** | `RestApi` (edge-optimized, default) |
+| **Stage** | `dev` (via `deploy_options.stage_name`) |
+| **CORS preflight** | `ALL_ORIGINS`, `ALL_METHODS`, headers `Content-Type, Authorization` |
+| **Authorizer** | `CognitoUserPoolsAuthorizer` bound to the user pool above |
+
+Every domain stack re-hydrates this API via `apigateway.RestApi.from_rest_api_attributes(...)` and mounts its routes on `api.root`. The `CognitoAuthorizer` is re-used as-is — each domain route that opts into auth references `shared.authorizer`.
+
+The `dev` stage exists because we only ship one environment for the demo. The `ALL_ORIGINS` CORS is a demo-grade shortcut; production would allow-list the frontend origin explicitly.
+
+### 3.4 EventBridge Bus — `kismet-events`
+
+Custom bus (`events.EventBus`, name `kismet-events`). Every cross-domain event flows here — `profile.completed`, `swipe.created`, `match.created`, `message.sent`, `report.created`, `user.banned`, `user.deleted`, etc. Event shapes are catalogued in [`event-schema.json`](./event-schema.json).
+
+Publishing and subscription are wired through the `KismetService` construct (see §4): any service with `publish_events=True` gets `events:PutEvents` + an `EVENT_BUS_NAME` env var, and any `consume_events=[...]` declaration creates a `events.Rule` on this bus targeting the Lambda.
+
+### 3.5 S3 Photos Bucket — `kismet-photos-{account}-dev`
+
+| | |
+|---|---|
+| **Construct ID** | `PhotosBucket` |
+| **CORS** | `GET` + `PUT`, all origins, all headers |
+| **Public read** | `public_read_access=True` |
+| **BlockPublicAccess** | all four flags set to `False` (bucket ACLs + policies allowed public) |
+| **Removal policy** | `DESTROY` with `auto_delete_objects=True` |
+
+The bucket is intentionally publicly readable for the MVP — the frontend renders profile photos as plain `<img src="https://<cdn>/...">`. CORS `PUT` is present so the frontend can perform browser-direct uploads via presigned URLs issued by Photo Service (D1).
+
+The `{account}` interpolation (`self.account`) keeps the bucket name globally unique per AWS account without hard-coding it. The `-dev` suffix lines up with the `dev` API stage; a prod stack would pick its own suffix.
+
+See §5.4 for why "public read" is demo-only.
+
+### 3.6 CloudFront Distribution — photos CDN
+
+Wraps the photos bucket via `origins.S3BucketOrigin(self.photos_bucket)`. Default behavior:
+
+- `viewer_protocol_policy=REDIRECT_TO_HTTPS`
+- `allowed_methods=ALLOW_GET_HEAD_OPTIONS` (read-only; writes go direct to S3 via presigned PUT)
+- `cache_policy=CACHING_OPTIMIZED`
+- `compress=True` (gzip for text/SVG metadata files — most payload is JPEG which is already compressed)
+
+The computed domain is exposed as `self.photos_cdn_base_url = f"https://{...distribution_domain_name}"` and handed to Photo Service (D1) so its DB records store CDN URLs instead of raw S3 URLs.
+
+### 3.7 S3 Analytics Bucket — `kismet-analytics-{account}-dev`
+
+Plain bucket, no CORS, no public access, `DESTROY` + `auto_delete_objects=True`. Destination for D6 analytics output (batch exports, offline reports). No lifecycle rules configured yet.
+
+### 3.8 Kinesis Data Stream — **disabled**
+
+The CDK code currently has the Kinesis block commented out and sets:
+
+```python
+self.activity_stream = None  # Kinesis not yet available
+```
+
+The intent (per the comment in `shared_stack.py`) is a single-shard `kismet-activity-stream` re-enabled once the new AWS account's Kinesis quota is granted. Today, downstream D6 Activity Logger detects `activity_stream is None` and falls back to direct DynamoDB writes. The `ActivityStreamArn` CfnOutput is guarded by `if self.activity_stream:` so the export simply doesn't exist on this account.
+
+See §5.1.
+
+### 3.9 SNS Topic — `kismet-health-alerts`
+
+Plain `sns.Topic` named `kismet-health-alerts`. Subscribed to by the Health Monitor Lambda (outside this stack). No subscriptions are created in Shared itself — Shared only owns the topic.
+
+---
+
+## 4. Integration Patterns
+
+### 4.1 Cross-stack handoff via Python reference
+
+`app.py` passes `shared=SharedStack` into each domain stack. Inside each domain stack, `shared.user_pool`, `shared.authorizer`, `shared.event_bus`, `shared.photos_bucket`, `shared.photos_cdn_base_url`, `shared.health_alerts_topic` are consumed directly as CDK constructs. CDK turns the cross-stack references into CloudFormation exports/imports under the hood — that's what produces the deletion constraints in §5.3.
+
+### 4.2 REST API re-hydration
+
+Rather than threading `shared.api` as a live construct (which couples synth order tightly), each domain re-imports the API by attributes:
+
+```python
+apigateway.RestApi.from_rest_api_attributes(
+    self, "ImportedApi",
+    rest_api_id=shared.api.rest_api_id,
+    root_resource_id=shared.api.rest_api_root_resource_id,
+)
+```
+
+The resulting `IRestApi` is passed into `KismetService(..., api=imported_api, authorizer=shared.authorizer, ...)`. `KismetService` walks the path parts and `add_resource` / `add_method` under `api.root`, wiring the Cognito authorizer in for any route with `auth: True`.
+
+### 4.3 EventBridge re-hydration
+
+Same pattern for the bus:
+
+```python
+events.EventBus.from_event_bus_name(
+    self, "ImportedBus",
+    event_bus_name=shared.event_bus.event_bus_name,
+)
+```
+
+Passed to `KismetService(..., event_bus=imported_bus, publish_events=..., consume_events=[...])`. `KismetService` grants `PutEvents` and sets `EVENT_BUS_NAME` on publish, and creates `events.Rule`s on this bus for each consumed detail-type.
+
+### 4.4 Photo Service wiring (D1-specific)
+
+D1's Photo Service receives both `shared.photos_bucket` (for `grant_read_write` and presigned URL issuance) and `shared.photos_cdn_base_url` (injected as an env var so stored URLs resolve to the CDN, not the raw S3 host).
+
+---
+
+## 5. CloudFormation Outputs
+
+`SharedStack` emits the following `CfnOutput`s — these are the public contract of the stack:
+
+| Output | Value | Consumer |
+|--------|-------|----------|
+| `UserPoolId` | `self.user_pool.user_pool_id` | Frontend `.env.local`, README live-demo block |
+| `UserPoolClientId` | `self.user_pool_client.user_pool_client_id` | Frontend `.env.local` |
+| `ApiUrl` | `self.api.url` | Frontend `.env.local`, README |
+| `EventBusArn` | `self.event_bus.event_bus_arn` | Diagnostic / AWS-console lookup |
+| `PhotosBucketName` | `self.photos_bucket.bucket_name` | Photo Service env (set via CDK reference, not the export) |
+| `PhotosCdnBaseUrl` | `https://<distribution_domain>` | Frontend `.env.local`, Photo Service |
+| `ActivityStreamArn` | stream ARN **if** Kinesis is enabled | D6 Activity Logger (currently absent — see §5.1) |
+
+Frontend env files are hand-populated from `cdk deploy` output; there is no automated sync.
+
+---
+
+## 6. Known Gotchas / Postmortems
+
+### 6.1 Kinesis disabled on the new AWS account
+
+`self.activity_stream = None` is intentional, not a bug. The new AWS account the project moved to does not yet have Kinesis activated. Any downstream that relies on the stream must tolerate `None` — today, D6 Activity Logger does so by falling back to direct DynamoDB writes. When the quota is granted, uncomment the `kinesis.Stream(...)` block, redeploy Shared, and D6 will re-discover the stream by ARN.
+
+### 6.2 Imported-API stage does not auto-redeploy on route changes
+
+When a domain stack adds or modifies a route on the **imported** REST API, CDK creates/updates the Method/Resource but does **not** automatically trigger a redeployment of the `dev` stage. Symptom: `curl` against the new route returns 403 or `Missing Authentication Token` until the stage is manually redeployed (console → "Deploy API" → `dev`).
+
+This has bitten the team multiple times; see `docs/postmortem/d3-route-revert-2026-04-12.md` for the most recent case. Tracked as **#118**.
+
+### 6.3 Cross-stack deletion/update blocked while exports are in use
+
+Because domain stacks `from_event_bus_name`/`from_rest_api_attributes` off Shared's outputs, CloudFormation records these as exports **in use**. Attempting to update Shared in a way that would change or delete one of those exports fails with `UPDATE_ROLLBACK_COMPLETE` and `Export ... cannot be updated as it is in use by KismetDomainN`.
+
+Mitigation: deploy the affected domain first with `cdk deploy KismetDomainN --exclusively` so the domain stops referencing the old export, then update Shared. In the worst case, destroy/recreate in a specific order per the stack dependency graph.
+
+### 6.4 Photos bucket is public-read (MVP only)
+
+`public_read_access=True` + `BlockPublicAccess` all-off is a demo-grade choice. Production should flip to:
+- private bucket
+- CloudFront Origin Access Identity / Origin Access Control
+- signed URLs for viewing (not just PUT)
+
+This is not tracked as its own issue yet — it's an explicit demo-scope call-out.
+
+### 6.5 `RemovalPolicy.DESTROY` on UserPool and buckets
+
+Every stateful resource in Shared is `DESTROY`. Teardown is clean; accidental teardown is catastrophic. Only acceptable because the demo account holds no real user data.
+
+---
+
+## 7. Open Follow-ups
+
+- **#118** — CDK: imported API Gateway stage auto-redeploy on domain route changes. (see §6.2)
+- **Re-enable Kinesis** — uncomment the `kinesis.Stream(...)` block in `shared_stack.py` once the AWS account quota is granted. Remove the `self.activity_stream = None` fallback and drop D6's direct-write path.
+- **Lock down photos bucket** — switch to OAC + signed URLs before any non-demo deployment. (see §6.4)
+- **Tighten Cognito password policy + CORS origin allow-list** before any non-demo deployment.
+- **Frontend env sync** — `UserPoolId`, `UserPoolClientId`, `ApiUrl`, `PhotosCdnBaseUrl` are hand-copied from `cdk deploy` output. A small script that reads stack outputs and writes `.env.local` would remove a manual step.
+
+---
+
+## 8. References
+
+- Top-level overview: [`Design_Doc.md` §4 "Shared Infrastructure"](./Design_Doc.md)
+- Event shapes published on `kismet-events`: [`event-schema.json`](./event-schema.json)
+- Reusable service construct that consumes Shared: [`kismet_constructs/kismet_service.py`](../../infra/kismet_constructs/kismet_service.py)
+- Stack wiring: [`infra/app.py`](../../infra/app.py)
+- Domain example of consuming Shared: [`Domain2_Design.md`](./Domain2_Design.md)
+- Postmortems touching Shared:
+  - [`postmortem/d3-route-revert-2026-04-12.md`](../postmortem/d3-route-revert-2026-04-12.md) — imported-API stage redeploy (#118)
+  - [`postmortem/chat-duplicate-messages-2026-04-14.md`](../postmortem/chat-duplicate-messages-2026-04-14.md)
+  - [`postmortem/ios-fetch-load-failed-2026-04-14.md`](../postmortem/ios-fetch-load-failed-2026-04-14.md)


### PR DESCRIPTION
## Summary

Six new deep-dive design docs to match \`Domain2_Design.md\`. Same template: Purpose → Architecture → Services → Data Layer → Event Flows → Cross-Service Deps → Known Gotchas → Open Follow-ups → References.

| Doc | Lines |
|-----|-------|
| \`SharedStack_Design.md\` | 256 |
| \`Domain1_Design.md\` (Identity) | 299 |
| \`Domain3_Design.md\` (Messaging) | 267 |
| \`Domain4_Design.md\` (Moderation) | 286 |
| \`Domain5_Design.md\` (Notifications) | 286 |
| \`Domain6_Design.md\` (Analytics) | 335 |

All drafted against **live source code** (not the top-level Design_Doc) to catch drift.

## 🚨 Drift found during cross-verification (separate follow-ups)

These are real bugs / doc errors surfaced by the research pass — each doc flags them honestly rather than covering them up:

1. **Rekognition retry never made it to main.** PR #117 squash-merged only 4 frontend files; the S3 eventual-consistency in-Lambda retry from commit \`8f54213\` was dropped on the floor. Re-apply coming in a separate PR.
2. **D5 Event Bus Service doesn't route events** — it's audit+replay. Design_Doc.md §3 description is misleading.
3. **D5 Push Notification has no \`user.deleted\` handler** — cleanup gap.
4. **D6 Admin Dashboard ban endpoint skips the event bus.** Writes \`status=banned\` directly but does not publish \`profile.banned\` → breaks the cascade from #119.
5. **D6 Admin Dashboard has no admin-role enforcement** — any authenticated user passes. Demo-only.
6. **D6 \`?status=PENDING\` filter from #114** is not wired into admin flagged-content listing.
7. **D3 \`POST /messages/read\`** route exists in CDK but handler is unimplemented.
8. **D1 email-verification-service** exists as code but isn't provisioned by \`domain1_stack.py\` (Cognito auto-verify made it redundant).

Will file 1-issue-per-drift after this merges.

## Test plan

- [ ] Each doc references \`lambda_function.py\` line numbers or explicit CDK config where claims are made — spot-check any 3 and confirm accuracy
- [ ] README structure section lists all 7 new docs
- [ ] Link checker: no broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)