### PR TITLE
fix(moderation): re-apply Rekognition S3 retry (dropped by #117 squash)

### DIFF
--- a/services/domain-4-moderation/image-moderation-service/lambda_function.py
+++ b/services/domain-4-moderation/image-moderation-service/lambda_function.py
@@ -294,21 +294,35 @@ def detect_moderation_labels(
     *,
     bucket: str,
 ) -> Tuple[List[Dict[str, Any]], float, bool, Optional[str]]:
-    try:
-        resp = rekognition.detect_moderation_labels(
-            Image={
-                "S3Object": {
-                    "Bucket": bucket,
-                    "Name": s3_key,
-                }
-            },
-            MinConfidence=REKOGNITION_MIN_CONFIDENCE,
-        )
-    except ClientError as e:
-        code = e.response.get("Error", {}).get("Code", "RekognitionError")
-        if code in ("InvalidS3ObjectException", "S3ObjectNotFoundException"):
-            raise RuntimeError(f"IMAGE_NOT_FOUND:{code}") from e
-        raise RuntimeError(f"REKOGNITION:{code}") from e
+    # S3 PutObject is strongly consistent, but Rekognition occasionally can't
+    # see a freshly uploaded object on its first read. Retry in-process so we
+    # don't fall through to EventBridge's ~60s retry window.
+    last_err: Optional[ClientError] = None
+    resp = None
+    for attempt in range(4):
+        try:
+            resp = rekognition.detect_moderation_labels(
+                Image={
+                    "S3Object": {
+                        "Bucket": bucket,
+                        "Name": s3_key,
+                    }
+                },
+                MinConfidence=REKOGNITION_MIN_CONFIDENCE,
+            )
+            break
+        except ClientError as e:
+            code = e.response.get("Error", {}).get("Code", "RekognitionError")
+            if code in ("InvalidS3ObjectException", "S3ObjectNotFoundException") and attempt < 3:
+                # eventual-consistency retry: 0.5s, 1s, 2s
+                time.sleep(0.5 * (2 ** attempt))
+                last_err = e
+                continue
+            if code in ("InvalidS3ObjectException", "S3ObjectNotFoundException"):
+                raise RuntimeError(f"IMAGE_NOT_FOUND:{code}") from e
+            raise RuntimeError(f"REKOGNITION:{code}") from e
+    if resp is None:
+        raise RuntimeError("IMAGE_NOT_FOUND:InvalidS3ObjectException") from last_err
 
     labels_out: List[Dict[str, Any]] = []
     max_conf = 0.0


### PR DESCRIPTION
## Summary

Restores the in-process Rekognition retry from commit \`8f54213\` that was lost when PR #117 was squash-merged — the squash only picked up the 4 frontend files, leaving the backend change on the orphaned branch.

Surfaced during the \`Domain4_Design.md\` cross-verification pass (#125) when the research agent noted the described retry didn't exist on main.

## Behavior change

**Before:** Rekognition hits \`InvalidS3ObjectException\` when S3 metadata hasn't propagated yet → Lambda fails → EventBridge waits ~60s before retry → frontend's 16s poll expires → user never sees the rejection dialog.

**After:** Retry in-process with 0.5 → 1 → 2s backoff (up to 4 attempts total ≈ 3.5s worst case). Well within the frontend's poll window.

## Test plan

- [ ] Upload a gun/inappropriate JPEG → rejection dialog appears within ~10s even if first Rekognition call fails with \`InvalidS3ObjectException\`
- [ ] Upload a normal JPEG → no dialog, photo shows in grid
- [ ] CloudWatch logs for \`kismet-image-moderation\` show retry messages only when needed

## Deploy

\`AWS_PROFILE=new cdk deploy KismetDomain4 --exclusively\`