### PR TITLE
fix(infra): accept CLI string for enableActivityStream context

### DIFF
--- a/infra/stacks/shared_stack.py
+++ b/infra/stacks/shared_stack.py
@@ -128,7 +128,10 @@ class SharedStack(cdk.Stack):
         # Opt-in via CDK context: `cdk deploy -c enableActivityStream=true`
         # or by setting `"enableActivityStream": true` in cdk.json context.
         # Disabled by default to avoid unexpected cost (~$11/month per shard).
-        if self.node.try_get_context("enableActivityStream") is True:
+        # Accept both the JSON boolean (from cdk.json) and the string "true"
+        # (from `-c key=true` on the CLI, which CDK does not coerce to bool).
+        _enable_stream = self.node.try_get_context("enableActivityStream")
+        if _enable_stream is True or _enable_stream == "true":
             self.activity_stream = kinesis.Stream(
                 self,
                 "ActivityStream",


### PR DESCRIPTION
## Summary

The D6 deploy guide tells operators to enable the activity stream with:

```
cdk deploy KismetShared KismetDomain6 -c enableActivityStream=true
```

But this command silently does nothing today — no Kinesis stream is created, no Firehose, and `kismet-activity-logger` runs without `KINESIS_STREAM_NAME`. We hit this when redeploying onto a fresh account: the documented command appeared to succeed but the activity pipeline was never wired up.

Root cause: [`shared_stack.py:131`](https://github.com/Kismet2026/Kismet/blob/main/infra/stacks/shared_stack.py#L131) uses `is True`, which only matches the Python boolean. `cdk -c key=value` passes the value as a **string**, not coerced to bool. Verified with a debug `print`:

| `cdk.json` | CLI flag | `try_get_context` returns | type | matches `is True` |
|---|---|---|---|---|
| `false` | (none) | `False` | bool | ❌ |
| `false` | `-c enableActivityStream=true` | `'true'` | **str** | ❌ |
| `true`  | (none) | `True` | bool | ✅ |

Only `cdk.json` opt-in worked. The CLI form silently fell through to `self.activity_stream = None`.

## Fix

Accept both the JSON boolean (cdk.json) and the literal string `"true"` (CLI). Minimal change, preserves default-off behavior.

```python
_enable_stream = self.node.try_get_context("enableActivityStream")
if _enable_stream is True or _enable_stream == "true":
```

## Verified

- `cdk synth KismetShared -c enableActivityStream=true` → template now contains `kismet-activity-stream` (was 0 before)
- `cdk synth KismetShared` (no flag, cdk.json=false) → still 0 references, default stays off
- Live deploy on the new AWS account confirmed the upstream pipeline lights up once the context is honored (Kinesis stream + Firehose created, `KINESIS_STREAM_NAME` env var populated on `kismet-activity-logger`)

## Test plan

- [x] `cdk synth KismetShared -c enableActivityStream=true` produces `AWS::Kinesis::Stream`
- [x] `cdk synth KismetShared` (no flag) produces no `AWS::Kinesis::Stream`
- [x] Existing D5/D6 unit suites unaffected (single-line condition change)