### PR TITLE
chore: redact public Vercel demo URL from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ service-name/
 | Domain 5 — Notifications | Deployed |
 | Domain 6 — Analytics | Deployed |
 
-**Live demo:** https://frontend-hazel-two-58.vercel.app
+**Live demo:** available on request (URL withheld to limit public exposure)
 - 49 cross-domain integration tests passing
 - End-to-end flow verified on mobile web: signup → profile → discover → swipe → match → chat
 

--- a/docs/standup/2026-04-12.md
+++ b/docs/standup/2026-04-12.md
@@ -15,7 +15,7 @@
 - **Profile**: view/edit, photo grid, email preferences (D5), logout
 - **Safety**: report dialog in chat (D4), notification badge on tab bar (D5)
 - **Design**: custom dark palette (plum/mauve/cream/amber), Dancing Script logo, Libre Baskerville headings, DM Sans body, Phosphor Icons, mobile-first
-- Deployed to **Vercel**: https://frontend-hazel-two-58.vercel.app
+- Deployed to **Vercel** (URL withheld to limit public exposure)
 
 ### Infra & DevOps
 - **CORS fix** ([#94](https://github.com/Kismet2026/Kismet/pull/94)) — added `add_cors_preflight` to `KismetService` for cross-stack imported APIs. Without this, all browser API calls from Vercel were blocked (403 on OPTIONS preflight)

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -29,6 +29,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Kismet",
   description: "Find your destined match through the wisdom of BaZi",
+  robots: { index: false, follow: false },
 };
 
 export default function RootLayout({

--- a/frontend/src/app/robots.ts
+++ b/frontend/src/app/robots.ts
@@ -1,0 +1,10 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      disallow: "/",
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Removes the live Vercel demo URL from two browseable spots:
- `README.md` (the most-clicked page on the repo)
- `docs/standup/2026-04-12.md`

Replaced with "available on request" so the context isn't lost.

## Caveat — this is mild, not real protection

The same URL still appears in postmortems and `frontend/FRONTEND_PLAN.md` — those are operator docs the team needs. If the goal is real DDoS resistance, that comes from Vercel's edge (and optionally enabling Deployment Protection / password gating in the Vercel project settings), not from removing references in markdown.

## Test plan

- [x] `git grep frontend-hazel-two-58` after the change → no hits in README or top-level standup