### PR TITLE
docs(readme): add Getting Started section for the Next.js frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,33 @@ service-name/
 3. Read your service's README for setup instructions
 4. Deploy: `cd infra && npx cdk deploy <StackName> --app "python3 app.py"`
 
+### User frontend (Next.js, Vercel)
+
+Local:
+
+```bash
+cd frontend
+npm install
+npm run dev     # http://localhost:3000
+```
+
+Required env vars (put them in `frontend/.env.local`):
+
+```
+NEXT_PUBLIC_API_BASE_URL=https://<api-id>.execute-api.<region>.amazonaws.com/dev
+NEXT_PUBLIC_WS_URL=wss://<ws-api-id>.execute-api.<region>.amazonaws.com/dev
+NEXT_PUBLIC_COGNITO_USER_POOL_ID=<KismetShared.UserPoolId>
+NEXT_PUBLIC_COGNITO_CLIENT_ID=<KismetShared.UserPoolClientId>
+```
+
+All four values come from `cdk deploy KismetShared` outputs.
+
+Deploy (Vercel):
+
+1. Connect `Kismet2026/Kismet` in Vercel, set **Root Directory** to `frontend/`
+2. Add the same four `NEXT_PUBLIC_*` vars in **Project Settings → Environment Variables**
+3. Pushes to `main` auto-deploy to production; PRs get preview URLs
+
 ### Admin dashboard (Streamlit)
 
 Local:


### PR DESCRIPTION
## Summary

Fills a gap in the README: before this, Getting Started jumped straight from `cdk deploy` to the Streamlit admin dashboard and never documented how to run or deploy the user-facing Next.js frontend. Now it does.

## What's in the new section

- **Local dev**: `cd frontend && npm install && npm run dev`
- **Env vars**: the four `NEXT_PUBLIC_*` vars the app reads (`API_BASE_URL`, `WS_URL`, `COGNITO_USER_POOL_ID`, `COGNITO_CLIENT_ID`), sourced from `cdk deploy KismetShared` outputs
- **Vercel deploy**: Root Directory = `frontend/`, same env vars in Project Settings, auto-deploy on `main`

Placed right before the Admin dashboard subsection so Getting Started now reads top-to-bottom: CDK → user frontend → admin dashboard.

## Test plan

- [x] Rendered README in GitHub preview, section anchors look right
- [x] Verified the four env var names against `frontend/.env.local` (confirmed present: `NEXT_PUBLIC_API_BASE_URL`, `NEXT_PUBLIC_WS_URL`, `NEXT_PUBLIC_COGNITO_USER_POOL_ID`, `NEXT_PUBLIC_COGNITO_CLIENT_ID`)