### PR TITLE
fix(d1): ban disables Cognito + blocks profile create/update (#148)

### DIFF
--- a/services/domain-1-identity/profile-service/lambda_function.py
+++ b/services/domain-1-identity/profile-service/lambda_function.py
@@ -95,8 +95,19 @@ def handle_create(user_id: str, body: Dict[str, Any]) -> Dict[str, Any]:
         return _response(400, {"code": "VALIDATION_ERROR", "message": "location is required."})
 
     table = dynamodb.Table(PROFILES_TABLE_NAME)
-    existing = table.get_item(Key={"PK": f"USER#{user_id}", "SK": "PROFILE"})
-    if existing.get("Item"):
+    existing = table.get_item(
+        Key={"PK": f"USER#{user_id}", "SK": "PROFILE"},
+        ConsistentRead=True,
+    )
+    existing_item = existing.get("Item")
+    if existing_item:
+        # Banned users must not be able to re-create a profile — this closes
+        # the loophole where onboarding UI re-triggers after ban (#148).
+        if existing_item.get("status") == "banned":
+            return _response(403, {
+                "code": "FORBIDDEN",
+                "message": "This account has been suspended.",
+            })
         return _response(409, {"code": "CONFLICT", "message": "Profile already exists."})
 
     now = datetime.now(timezone.utc).isoformat()
@@ -147,8 +158,20 @@ def handle_update(caller_id: str, user_id: str, body: Dict[str, Any]) -> Dict[st
         return _response(403, {"code": "FORBIDDEN", "message": "You can only update your own profile."})
 
     table = dynamodb.Table(PROFILES_TABLE_NAME)
-    if not table.get_item(Key={"PK": f"USER#{user_id}", "SK": "PROFILE"}).get("Item"):
+    existing_item = table.get_item(
+        Key={"PK": f"USER#{user_id}", "SK": "PROFILE"},
+        ConsistentRead=True,
+    ).get("Item")
+    if not existing_item:
         return _response(404, {"code": "NOT_FOUND", "message": "Profile not found."})
+    # Banned users cannot update their profile — this would otherwise let a
+    # logged-in banned user change name/bio/photos and effectively keep using
+    # the account (#148).
+    if existing_item.get("status") == "banned":
+        return _response(403, {
+            "code": "FORBIDDEN",
+            "message": "This account has been suspended.",
+        })
 
     updates = {k: json.loads(json.dumps(v), parse_float=Decimal) if isinstance(v, (dict, list, float)) else v
                 for k, v in body.items() if k in UPDATABLE_FIELDS}
@@ -331,6 +354,23 @@ def handle_user_banned(detail: Dict[str, Any]) -> Dict[str, Any]:
             ExpressionAttributeValues=expr_values,
         )
         item = table.get_item(Key={"PK": f"USER#{user_id}", "SK": "PROFILE"}).get("Item", item)
+
+    # Disable the Cognito user so the banned user cannot log in.  Without this,
+    # login still succeeds (Cognito auth isn't tied to DynamoDB profile.status),
+    # and the banned user can hit the onboarding flow to keep using the app.
+    # Closes the loophole described in #148.  Best-effort: DynamoDB is the source
+    # of truth for ban state; a Cognito failure logs a warning but doesn't fail
+    # the handler (so EventBridge doesn't retry forever on a transient error).
+    if COGNITO_USER_POOL_ID:
+        try:
+            cognito.admin_disable_user(
+                UserPoolId=COGNITO_USER_POOL_ID,
+                Username=user_id,
+            )
+        except cognito.exceptions.UserNotFoundException:
+            logger.warning("Cognito user missing while disabling for ban: %s", user_id)
+        except ClientError:
+            logger.exception("Failed to disable Cognito user for ban: %s", user_id)
 
     events.put_events(Entries=[{
         "Source": "kismet.profile-service",


### PR DESCRIPTION
## Summary

Closes #148 — second-order ban bypass. #121/#124 prevented re-registration after a banned user deletes their account. This PR plugs the more direct hole: without deleting anything, a banned user could just log in and re-onboard because \`handle_user_banned\` only updated DynamoDB and never touched Cognito.

## Changes

\`services/domain-1-identity/profile-service/lambda_function.py\`:

1. **\`handle_user_banned\`** — after writing \`status=banned\`, call \`cognito.admin_disable_user\`. Best-effort: a Cognito error logs + returns success so EventBridge doesn't retry on transient blips.
2. **\`handle_create\`** — if the existing profile row is \`status=banned\`, return **403 FORBIDDEN** (instead of the usual 409).
3. **\`handle_update\`** — read with \`ConsistentRead=True\`, reject with 403 if banned. Defense-in-depth for stale-JWT scenarios.

IAM for \`cognito-idp:AdminDisableUser\` was already granted in PR #124, so no CDK change needed.

## Test plan

- [ ] Active user signs up / logs in / onboards normally
- [ ] User gets banned (auto or admin) → \`profile.status=banned\` AND Cognito \`Enabled=False\`
- [ ] Banned user tries to log in → \`NotAuthorizedException: User is disabled\`
- [ ] Banned user with stale JWT → \`POST /profiles\` returns 403, \`PUT /profiles/{userId}\` returns 403

## Context

Verified live this afternoon on NEW account: John (Olivia Shen's account) was banned at 16:50Z, immediately logged back in, re-onboarded. I manually \`admin-disable-user\`'d + reset profile status to close the hole. This PR prevents future recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)