### PR TITLE
fix(d6): convert flagged content timestamps to PT

### DIFF
--- a/frontend/admin/app.py
+++ b/frontend/admin/app.py
@@ -133,7 +133,7 @@ with tab2:
     else:
         for item in data["items"]:
             with st.expander(
-                f"{item['contentId']} — {item['reason']} ({item.get('flaggedAt', '')})"
+                f"{item['contentId']} — {item['reason']} ({to_pt(item.get('flaggedAt', ''))})"
             ):
                 st.write(f"**Type:** {item['type']}")
                 st.write(f"**User:** {item['userId']}")

--- a/infra/cdk.json
+++ b/infra/cdk.json
@@ -8,6 +8,6 @@
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
     "@aws-cdk/aws-cognito:enableStandardAttributesInUserPool": true,
     "@aws-cdk/core:checkSecretUsage": true,
-    "enableActivityStream": true
+    "enableActivityStream": false
   }
 }

--- a/infra/cdk.json
+++ b/infra/cdk.json
@@ -8,6 +8,6 @@
     "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
     "@aws-cdk/aws-cognito:enableStandardAttributesInUserPool": true,
     "@aws-cdk/core:checkSecretUsage": true,
-    "enableActivityStream": false
+    "enableActivityStream": true
   }
 }


### PR DESCRIPTION
## What

Convert the flagged content tab expander timestamps from raw UTC to Pacific Time, consistent with other timestamps in the admin dashboard.

## Change

- `frontend/admin/app.py`: wrap `flaggedAt` in the expander title with `to_pt()` so it displays as `YYYY-MM-DD HH:MM AM/PM PT` instead of raw ISO UTC string

## Testing

No backend changes. Visual fix only — verified by inspection against the existing `to_pt()` helper used elsewhere in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)