### PR TITLE
test(d2-discovery): unbreak CI after #151 default gender filter

### DIFF
--- a/services/domain-2-discovery/discovery-service/tests/test_lambda_function.py
+++ b/services/domain-2-discovery/discovery-service/tests/test_lambda_function.py
@@ -209,6 +209,7 @@ class TestGetCandidates:
     @patch('lambda_function.table')
     def test_returns_candidates_with_bazi_score(self, mock_table, mock_swipe, mock_bazi):
         mock_swipe.query.return_value = {'Items': []}
+        mock_table.get_item.return_value = {}  # caller profile not found → no default gender filter
         mock_bazi.return_value = {'1999-05-15': 92}
         mock_table.scan.return_value = {
             'Items': [
@@ -232,6 +233,7 @@ class TestGetCandidates:
     @patch('lambda_function.table')
     def test_bazi_score_none_when_not_in_top200(self, mock_table, mock_swipe, mock_bazi):
         mock_swipe.query.return_value = {'Items': []}
+        mock_table.get_item.return_value = {}  # caller profile not found → no default gender filter
         mock_bazi.return_value = {'2000-01-01': 85}
         mock_table.scan.return_value = {
             'Items': [
@@ -254,6 +256,7 @@ class TestGetCandidates:
         mock_swipe.query.return_value = {
             'Items': [{'targetUserId': 'user-456'}]
         }
+        mock_table.get_item.return_value = {}  # caller profile not found → no default gender filter
         mock_bazi.return_value = {}
         mock_table.scan.return_value = {
             'Items': [
@@ -278,6 +281,7 @@ class TestGetCandidates:
     @patch('lambda_function.table')
     def test_filters_by_gender(self, mock_table, mock_swipe, mock_bazi):
         mock_swipe.query.return_value = {'Items': []}
+        mock_table.get_item.return_value = {}  # caller profile not found → no default gender filter
         mock_bazi.return_value = {}
         mock_table.scan.return_value = {
             'Items': [
@@ -302,6 +306,7 @@ class TestGetCandidates:
     @patch('lambda_function.table')
     def test_filters_by_age(self, mock_table, mock_swipe, mock_bazi):
         mock_swipe.query.return_value = {'Items': []}
+        mock_table.get_item.return_value = {}  # caller profile not found → no default gender filter
         mock_bazi.return_value = {}
         mock_table.scan.return_value = {
             'Items': [


### PR DESCRIPTION
#151 added a default gender filter driven by the caller's \`preferredGender\` from their kismet-discovery profile row. TestGetCandidates tests mocked \`table.scan\` but not \`table.get_item\` — the default MagicMock for \`get_item().get('Item', {})\` returned a truthy mock, which became the gender filter and rejected every candidate. CI on #151 and #152 showed 4 \`count=0\` failures.

This PR sets \`mock_table.get_item.return_value = {}\` in each affected test so the caller profile lookup explicitly returns "not found" and the handler keeps its no-filter behaviour (matching what those pre-existing tests were written to assert).

No production code change.