### PR TITLE
fix(d6): grant activity-logger kinesis:PutRecord on the activity stream

### DIFF
--- a/infra/stacks/domain6_stack.py
+++ b/infra/stacks/domain6_stack.py
@@ -137,7 +137,16 @@ class Domain6Stack(cdk.Stack):
                 "user.reported",
             ],
             publish_events=False,
-            extra_policies=[],
+            extra_policies=(
+                [
+                    iam.PolicyStatement(
+                        actions=["kinesis:PutRecord", "kinesis:PutRecords"],
+                        resources=[activity_stream.stream_arn],
+                    ),
+                ]
+                if activity_stream is not None
+                else []
+            ),
             environment=(
                 {"ACTIVITY_LOG_TABLE": "kismet-activity-log", "KINESIS_STREAM_NAME": activity_stream.stream_name}
                 if activity_stream is not None

--- a/services/domain-2-discovery/discovery-service/tests/test_lambda_function.py
+++ b/services/domain-2-discovery/discovery-service/tests/test_lambda_function.py
@@ -209,6 +209,7 @@ class TestGetCandidates:
     @patch('lambda_function.table')
     def test_returns_candidates_with_bazi_score(self, mock_table, mock_swipe, mock_bazi):
         mock_swipe.query.return_value = {'Items': []}
+        mock_table.get_item.return_value = {}  # caller profile not found → no default gender filter
         mock_bazi.return_value = {'1999-05-15': 92}
         mock_table.scan.return_value = {
             'Items': [
@@ -232,6 +233,7 @@ class TestGetCandidates:
     @patch('lambda_function.table')
     def test_bazi_score_none_when_not_in_top200(self, mock_table, mock_swipe, mock_bazi):
         mock_swipe.query.return_value = {'Items': []}
+        mock_table.get_item.return_value = {}  # caller profile not found → no default gender filter
         mock_bazi.return_value = {'2000-01-01': 85}
         mock_table.scan.return_value = {
             'Items': [
@@ -254,6 +256,7 @@ class TestGetCandidates:
         mock_swipe.query.return_value = {
             'Items': [{'targetUserId': 'user-456'}]
         }
+        mock_table.get_item.return_value = {}  # caller profile not found → no default gender filter
         mock_bazi.return_value = {}
         mock_table.scan.return_value = {
             'Items': [
@@ -278,6 +281,7 @@ class TestGetCandidates:
     @patch('lambda_function.table')
     def test_filters_by_gender(self, mock_table, mock_swipe, mock_bazi):
         mock_swipe.query.return_value = {'Items': []}
+        mock_table.get_item.return_value = {}  # caller profile not found → no default gender filter
         mock_bazi.return_value = {}
         mock_table.scan.return_value = {
             'Items': [
@@ -302,6 +306,7 @@ class TestGetCandidates:
     @patch('lambda_function.table')
     def test_filters_by_age(self, mock_table, mock_swipe, mock_bazi):
         mock_swipe.query.return_value = {'Items': []}
+        mock_table.get_item.return_value = {}  # caller profile not found → no default gender filter
         mock_bazi.return_value = {}
         mock_table.scan.return_value = {
             'Items': [


### PR DESCRIPTION
## Root cause

The `activity-logger` Lambda reads `KINESIS_STREAM_NAME` from its environment and calls `PutRecord` on every EventBridge event it handles. Its IAM role, however, had `extra_policies=[]` — no `kinesis:PutRecord` grant anywhere.

On the live deploy (new account, `enableActivityStream=true`):

- Kinesis stream + Firehose both **ACTIVE** and correctly wired (source, dest, buffer all fine)
- `activity-logger` invocation count last 6h: **69**
- `activity-logger` error count last 6h: **51** (73%+ error rate)
- CloudWatch Logs:
  ```
  [ERROR] RuntimeError: failed to write to Kinesis stream kismet-activity-stream
    File "/var/task/lambda_function.py", line 96, in handle_eventbridge
      _write_to_kinesis(current_record, current_user_id)
    File "/var/task/lambda_function.py", line 222, in _write_to_kinesis
      raise RuntimeError(...)
  ```
- Kinesis `IncomingRecords` = 0 → Firehose `IncomingRecords` = 0 → S3 `events/` empty → Athena returns zeros

Since [#140](https://github.com/Kismet2026/Kismet/pull/140) made the Kinesis write fail loud (raise instead of swallow), the EventBridge path now also skips DynamoDB on the way out, so the admin dashboard's "Recent Activity Log (real-time, via DynamoDB)" stays empty too. The failure mode from the admin side looks like "analytics pipeline broken" but it's really an IAM gap.

## Fix

Add a `kinesis:PutRecord` + `kinesis:PutRecords` statement to `activity-logger`'s `extra_policies`, gated on `activity_stream is not None` to match the pattern already used for the env var and for Firehose creation:

```python
extra_policies=(
    [
        iam.PolicyStatement(
            actions=["kinesis:PutRecord", "kinesis:PutRecords"],
            resources=[activity_stream.stream_arn],
        ),
    ]
    if activity_stream is not None
    else []
),
```

## Verified

Diagnostic commands run against the live deploy to confirm:

- `aws kinesis describe-stream --stream-name kismet-activity-stream` → ACTIVE
- `aws firehose describe-delivery-stream --delivery-stream-name kismet-activity-firehose` → ACTIVE, source/dest correct
- `aws s3 ls s3://kismet-analytics-<account>-dev/events/` → empty
- `aws cloudwatch get-metric-statistics` for `AWS/Kinesis IncomingRecords`, `AWS/Firehose IncomingRecords`, `AWS/Lambda Errors` on `kismet-activity-logger` — all line up with the root cause above
- `aws iam get-role-policy` on activity-logger's role — no `kinesis:*` statements present

## Deploy plan

1. Merge
2. `cdk deploy KismetDomain6 -c enableActivityStream=true` (Shared unchanged; only the Lambda's inline policy changes)
3. Watch `kismet-activity-logger` error rate drop to ~0; `AWS/Kinesis IncomingRecords` > 0 within one invocation; S3 `events/` gets its first object after the next 60s Firehose buffer flush; `/analytics/dashboard` starts returning non-zero.