### PR TITLE
fix(d6): emit JSON Lines from activity-logger so Athena reads all records

### DIFF
--- a/services/domain-6-analytics/activity-logger-service/lambda_function.py
+++ b/services/domain-6-analytics/activity-logger-service/lambda_function.py
@@ -213,9 +213,14 @@ def handle_get_recent(event):
 
 def _write_to_kinesis(record, partition_key):
     try:
+        # Append a newline so Firehose writes JSON Lines to S3. Kinesis records
+        # are concatenated byte-for-byte into Firehose output objects with no
+        # delimiter added, so without this trailing '\n' the S3 file is one
+        # long line of back-to-back JSON objects and Athena's JsonSerDe reads
+        # only the first record per object.
         kinesis.put_record(
             StreamName=KINESIS_STREAM_NAME,
-            Data=json.dumps(record).encode("utf-8"),
+            Data=(json.dumps(record) + "\n").encode("utf-8"),
             PartitionKey=partition_key,
         )
     except Exception as e:


### PR DESCRIPTION
## Root cause

Firehose delivers Kinesis records to S3 by concatenating their `Data` bytes with **no inserted delimiter** between records. Our `activity-logger` writes records as plain `json.dumps(record).encode("utf-8")` with no trailing newline, so every Firehose output object ends up as a single physical line of back-to-back JSON objects:

```
{"logId":"...","eventType":"user.created",...}{"logId":"...","eventType":"match.created",...}{"logId":...}
```

Athena's `JsonSerDe` splits on `\n` first, then parses each line as one JSON object. With `ignore.malformed.json = true` (set in `_ensure_catalog()`), it reads the first JSON from the line and silently drops everything after — so each Firehose output file contributes exactly **1 row** to Athena regardless of how many records it actually contains.

## Live symptom (verified after the IAM fix in [#155](https://github.com/Kismet2026/Kismet/pull/155))

- Pushed 14 synthetic events across 7 event types onto EventBridge
- `activity-logger` handled them cleanly (0 Lambda errors)
- `AWS/Kinesis IncomingRecords` = 15 ✅
- `AWS/Firehose IncomingRecords` = 15 ✅
- S3 got a 4029-byte object containing those 15 JSON records
- `wc -l` on that object = **0** (all on one line)
- Direct Athena:

  ```sql
  SELECT eventType, COUNT(*) FROM kismet_analytics.activity_events GROUP BY eventType
  ```

  returned only **2 rows total** (one per Firehose object), not 15.

This is exactly what the admin dashboard shows: DAU=1, Total Users=1, Matches Today=0, Messages Today=0.

## Fix

One-line change in `_write_to_kinesis`: append `\n` before putting the record:

```python
Data=(json.dumps(record) + "\n").encode("utf-8"),
```

This is the canonical Kinesis→Firehose→Athena pattern. Firehose does not insert delimiters on its own.

## Deploy plan

1. Merge
2. `cdk deploy KismetDomain6 -c enableActivityStream=true` (only the Lambda code bundle changes)
3. Push a few synthetic events, wait 60s for Firehose flush
4. Confirm `wc -l` on the new S3 object = N (one line per record), and that `/analytics/dashboard` returns non-zero for `matchesToday`, `messagesToday`, and a realistic `dau`

## Note on old S3 objects

Pre-fix objects in `s3://kismet-analytics-<account>-dev/events/` remain under-counted by Athena (only their first record is ever visible). They're all demo/verify traffic, so no cleanup is needed — they'll just count as 1 record each forever.