### PR TITLE
fix(d6): stringify eventData for Kinesis so Athena's json_extract_scalar works

### DIFF
--- a/services/domain-6-analytics/activity-logger-service/lambda_function.py
+++ b/services/domain-6-analytics/activity-logger-service/lambda_function.py
@@ -212,6 +212,16 @@ def handle_get_recent(event):
 
 
 def _write_to_kinesis(record, partition_key):
+    # Athena's `activity_events` table declares `eventData STRING`, so the
+    # JsonSerDe needs each record's `eventData` to be a JSON *string*, not a
+    # nested object — otherwise dashboard queries that call
+    # `json_extract_scalar(eventData, '$.matchId')` always get NULL.
+    # Stringify it here (Kinesis/Firehose/Athena path only). The DDB path
+    # below keeps the original dict so consumers of `kismet-activity-log`
+    # still see `eventData` as a native map.
+    kinesis_record = record
+    if isinstance(record.get("eventData"), dict):
+        kinesis_record = {**record, "eventData": json.dumps(record["eventData"])}
     try:
         # Append a newline so Firehose writes JSON Lines to S3. Kinesis records
         # are concatenated byte-for-byte into Firehose output objects with no
@@ -220,7 +230,7 @@ def _write_to_kinesis(record, partition_key):
         # only the first record per object.
         kinesis.put_record(
             StreamName=KINESIS_STREAM_NAME,
-            Data=(json.dumps(record) + "\n").encode("utf-8"),
+            Data=(json.dumps(kinesis_record) + "\n").encode("utf-8"),
             PartitionKey=partition_key,
         )
     except Exception as e:


### PR DESCRIPTION
## Root cause

Athena's `activity_events` table declares:

```sql
eventData STRING
```

But `activity-logger` was putting records with `eventData` as a **nested JSON object** (straight from `detail` of the EventBridge event):

```json
{"logId":"log-...", "eventType":"match.created", "eventData":{"matchId":"m2-ab", "userIds":[...]}, ...}
```

OpenX `JsonSerDe` resolves this type mismatch by handing `NULL` to the STRING column. So the dashboard query in [analytics-pipeline:129](services/domain-6-analytics/analytics-pipeline-service/lambda_function.py#L129):

```sql
COUNT(DISTINCT json_extract_scalar(eventData, '$.matchId')) AS matchesToday
```

always returns 0 — not because there are no `match.created` rows (there are), but because `json_extract_scalar` is called on `NULL`.

## Live symptom (verified on today's deploy after #155 + #156)

```
Athena GROUP BY eventType  →  match.created = 3
Dashboard matchesToday     →  0
Dashboard messagesToday    →  3  (works — no eventData extraction)
```

## Fix

Stringify `eventData` in the Kinesis path only:

```python
kinesis_record = record
if isinstance(record.get("eventData"), dict):
    kinesis_record = {**record, "eventData": json.dumps(record["eventData"])}
```

Kinesis → Firehose → S3 → Athena gets a shape that matches the declared schema; `json_extract_scalar` works as intended.

The **DDB path is unchanged** — `kismet-activity-log` still stores `eventData` as a native DynamoDB map so its consumers (e.g. `GET /analytics/log/recent`) keep seeing a structured object, not a JSON string.

## Test plan

- [x] Existing unit tests monkeypatch `_write_to_kinesis` itself, so the internal eventData transformation doesn't affect them
- [ ] After redeploy, push a batch of `match.created` events and confirm Athena's `SELECT json_extract_scalar(eventData, '$.matchId') ... GROUP BY` returns distinct `matchId` values instead of NULL
- [ ] Confirm dashboard `matchesToday` is non-zero

## Note on existing S3 data

Pre-fix objects in `s3://kismet-analytics-<account>-dev/events/` still have `eventData` as an object → Athena treats those rows' eventData as NULL forever. They're all demo traffic, so no cleanup is needed. Forward-looking queries will be correct.