### PR TITLE
fix(d6): remove Run Health Check button from admin dashboard

### DIFF
--- a/frontend/admin/app.py
+++ b/frontend/admin/app.py
@@ -203,18 +203,8 @@ with tab3:
 # ─── Tab 4: Health Monitor ────────────────────────────────────────────────────
 with tab4:
     st.header("Service Health")
-    col_refresh, col_check = st.columns([1, 1])
-
-    with col_refresh:
-        if st.button("Refresh"):
-            st.rerun()
-    with col_check:
-        if st.button("Run Health Check"):
-            result, err = api_post("/health/check")
-            if err:
-                st.error(f"Health check failed: {err}")
-            else:
-                st.success(f"Check complete — overall: {result['status']}")
+    if st.button("Refresh"):
+        st.rerun()
 
     data, err = api_get("/health")
     if err:


### PR DESCRIPTION
## What

Remove the "Run Health Check" button from the Health Monitor tab.

The button called `POST /health/check` which triggers SNS alerts and writes to DynamoDB history — not needed for the demo. The underlying logic and API endpoint are preserved, just hidden from the UI.

The "Refresh" button remains for reloading live CloudWatch data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)