### PR TITLE
fix(d6): remove Messages Today from stats tab

### DIFF
--- a/frontend/admin/app.py
+++ b/frontend/admin/app.py
@@ -110,12 +110,11 @@ with tab1:
     if err:
         st.error(f"Failed to load stats: {err}")
     else:
-        cols = st.columns(5)
+        cols = st.columns(4)
         cols[0].metric("Total Users", data["totalUsers"])
         cols[1].metric("Active Users", data["activeUsers"])
         cols[2].metric("Matches Today", data["matchesToday"])
-        cols[3].metric("Messages Today", data["messagesToday"])
-        cols[4].metric("Flagged Content", data["flaggedContentCount"])
+        cols[3].metric("Flagged Content", data["flaggedContentCount"])
         st.caption(f"Generated at: {to_pt(data.get('generatedAt', ''))}")
 
 # ─── Tab 2: Flagged Content ───────────────────────────────────────────────────


### PR DESCRIPTION
## What

Remove "Messages Today" metric from the Stats tab. The count was showing 0 due to a DynamoDB SK format mismatch. The same data is already available in the Analytics tab via Athena.