### PR TITLE
docs: update owner names and align admin README with current UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ A microservice dating app built on AWS — with BaZi (八字) compatibility matc
 | Domain | Members | Services |
 |--------|---------|----------|
 | **Identity & Profiles** | Quinn Gao, KS | Auth, Profile, Photo |
-| **Discovery & Matching** | Qinyuan | Discovery, Swipe, Match, Recommendation, BaZi |
+| **Discovery & Matching** | Qinyuan Shen | Discovery, Swipe, Match, Recommendation, BaZi |
 | **Messaging** | Parker, QX, Jiaxin | Chat Gateway, Message, Presence, Icebreaker |
 | **Safety & Moderation** | Yue, Xinyuan Fan (Amber) | Text Moderation, Image Moderation, Report, Rate Limiter |
 | **Notifications** | Nili, Xiaoyuan | Push Notification, Email, Event Bus, Scheduler |
-| **Analytics & Admin** | Jessica, Lingyun | Activity Logger, Analytics Pipeline, Admin Dashboard, Health Monitor |
-| **Integration** | Qinyuan | Cross-domain service orchestration |
-| **PM / Frontend** | Qinyuan | Architecture, frontend (AI-generated), coordination |
+| **Analytics & Admin** | Yuyi Zhang, Lingyun | Activity Logger, Analytics Pipeline, Admin Dashboard, Health Monitor |
+| **Integration** | Qinyuan Shen | Cross-domain service orchestration |
+| **PM / Frontend** | Qinyuan Shen | Architecture, frontend (AI-generated), coordination |
 
 ---
 
@@ -67,11 +67,11 @@ A microservice dating app built on AWS — with BaZi (八字) compatibility matc
 
 | Service | Owner | AWS Services | Description |
 |---------|-------|-------------|-------------|
-| Discovery Service | Qinyuan | Lambda, DynamoDB | Filter and browse candidates |
-| Swipe Service | Qinyuan | Lambda, DynamoDB | Record like/pass actions |
-| Match Service | Qinyuan | Lambda, DynamoDB, EventBridge | Detect mutual likes, ban cascade |
-| Recommendation Service | Qinyuan | Lambda, DynamoDB | Score and rank candidates |
-| BaZi Service | Qinyuan | Lambda | 八字 compatibility via external API |
+| Discovery Service | Qinyuan Shen | Lambda, DynamoDB | Filter and browse candidates |
+| Swipe Service | Qinyuan Shen | Lambda, DynamoDB | Record like/pass actions |
+| Match Service | Qinyuan Shen | Lambda, DynamoDB, EventBridge | Detect mutual likes, ban cascade |
+| Recommendation Service | Qinyuan Shen | Lambda, DynamoDB | Score and rank candidates |
+| BaZi Service | Qinyuan Shen | Lambda | 八字 compatibility via external API |
 
 ### Domain 3 — Messaging
 
@@ -104,8 +104,8 @@ A microservice dating app built on AWS — with BaZi (八字) compatibility matc
 
 | Service | Owner | AWS Services | Description |
 |---------|-------|-------------|-------------|
-| Activity Logger | Jessica | Kinesis Data Streams, Lambda | Capture user events |
-| Analytics Pipeline | Jessica | Kinesis Firehose, S3, Athena | Queryable data lake |
+| Activity Logger | Yuyi Zhang | Kinesis Data Streams, Lambda | Capture user events |
+| Analytics Pipeline | Yuyi Zhang | Kinesis Firehose, S3, Athena | Queryable data lake |
 | Admin Dashboard | Lingyun | Lambda, DynamoDB, Streamlit (SCC) | Stats, flagged content; Streamlit UI on Streamlit Community Cloud |
 | Health Monitor | Lingyun | CloudWatch, Lambda, SNS | Service health alerts |
 

--- a/frontend/admin/README.md
+++ b/frontend/admin/README.md
@@ -49,7 +49,6 @@ Reads `GET /admin/stats` and shows live admin metrics:
 - total users
 - active users
 - matches today
-- messages today
 - pending flagged content count
 
 ### Flagged Content Tab
@@ -62,12 +61,11 @@ Reads `GET /admin/users` with optional name search and supports banning/unbannin
 - `PUT /admin/users/{userId}/unban`
 
 ### Health Monitor Tab
-Reads `GET /health` and `GET /health/alarms`, and can trigger `POST /health/check`.
+Reads `GET /health` and `GET /health/alarms`.
 
 Health status meanings:
 
 - `healthy`: recent traffic exists and current metrics are within threshold
-- `unknown`: no recent invocations or no recent CloudWatch signal
 - `degraded`: recent traffic exists but latency is above threshold
 - `unhealthy`: recent traffic exists and error rate is above threshold
 


### PR DESCRIPTION
## Summary

Two files, all doc / naming cleanup — no code changes.

## README.md

- `Jessica` → `Yuyi Zhang` (D6 team row, Activity Logger, Analytics Pipeline)
- `Qinyuan` → `Qinyuan Shen` (D2 rows, Integration, PM / Frontend)

## frontend/admin/README.md

Align the admin dashboard README with the UI after recent demo-day cleanups:

- **Stats tab**: drop `- messages today` — this metric card was removed from the UI in [#160](https://github.com/Kismet2026/Kismet/pull/160).
- **Health Monitor tab**: drop `and can trigger POST /health/check` — the button was removed in [#159](https://github.com/Kismet2026/Kismet/pull/159). The endpoint still exists server-side, just no longer exposed in the UI.
- **Health status meanings**: drop the `unknown` bullet — [#158](https://github.com/Kismet2026/Kismet/pull/158) collapsed `unknown` into `healthy` for display, so documenting a status the UI no longer shows would be confusing. Backend still emits it and SNS rules still use it; this is purely a UI-facing doc change.