### PR TITLE
fix(d2): purge banned user from other users' recommendation caches

### DIFF
--- a/services/domain-2-discovery/recommendation-service/lambda_function.py
+++ b/services/domain-2-discovery/recommendation-service/lambda_function.py
@@ -56,7 +56,18 @@ def handler(event, context):
 
 
 def handle_user_deleted(event):
-    """Delete all recommendation cache entries for a deleted user."""
+    """Purge a banned/deleted user from the recommendation cache.
+
+    Two directions to clean:
+      1. Rows keyed on the user's own PK (the user's *view* of candidates) —
+         query by PK and batch-delete.
+      2. Rows where the user appears as a *candidate* inside someone else's
+         cache (candidateUserId == user_id). Without these, a banned user
+         keeps showing up in other users' /recommend responses until their
+         cache TTL flips. No GSI on candidateUserId, so we scan + filter.
+         Recommendation cache is small (bounded by active users × cache
+         size), so a filtered scan is acceptable here.
+    """
     detail = event.get('detail') or {}
     if isinstance(detail, str):
         try:
@@ -68,9 +79,11 @@ def handle_user_deleted(event):
         logger.warning('user.deleted event missing userId')
         return {'statusCode': 400, 'body': 'Missing userId'}
 
-    from boto3.dynamodb.conditions import Key
+    from boto3.dynamodb.conditions import Key, Attr
+
+    # 1) Delete the user's own cache rows.
     last_key = None
-    deleted_count = 0
+    own_deleted = 0
     while True:
         query_kwargs = {
             'KeyConditionExpression': Key('PK').eq(f'USER#{user_id}'),
@@ -81,12 +94,36 @@ def handle_user_deleted(event):
         with table.batch_writer() as batch:
             for item in result.get('Items', []):
                 batch.delete_item(Key={'PK': item['PK'], 'SK': item['SK']})
-                deleted_count += 1
+                own_deleted += 1
         last_key = result.get('LastEvaluatedKey')
         if not last_key:
             break
 
-    logger.info('Deleted %d recommendation cache entries for user %s', deleted_count, user_id)
+    # 2) Delete rows where this user appears as a candidate in *other* users'
+    #    caches. No GSI, so scan + filter. Bounded by total recommendation
+    #    rows which stays small for this project.
+    last_key = None
+    orphan_deleted = 0
+    while True:
+        scan_kwargs = {
+            'FilterExpression': Attr('candidateUserId').eq(user_id),
+            'ProjectionExpression': 'PK, SK',
+        }
+        if last_key:
+            scan_kwargs['ExclusiveStartKey'] = last_key
+        result = table.scan(**scan_kwargs)
+        with table.batch_writer() as batch:
+            for item in result.get('Items', []):
+                batch.delete_item(Key={'PK': item['PK'], 'SK': item['SK']})
+                orphan_deleted += 1
+        last_key = result.get('LastEvaluatedKey')
+        if not last_key:
+            break
+
+    logger.info(
+        'Recommendation cache cleanup for %s: own=%d orphan=%d',
+        user_id, own_deleted, orphan_deleted,
+    )
     return {'statusCode': 200, 'body': 'Recommendation cache deleted'}
 
 


### PR DESCRIPTION
## Root cause

`recommendation-service.handle_user_deleted` (bound to both `profile.banned` and `user.deleted`) only runs:

```python
table.query(KeyConditionExpression=Key('PK').eq(f'USER#{user_id}'))
```

That removes **the banned user's own** cache of candidates they were going to see, but leaves rows where the banned user appears as a **candidate** inside *someone else's* cache:

```
PK = USER#<victim-viewer>
SK = SCORE#<score>#<banned-user>
candidateUserId = <banned-user>
```

Those rows survive → `/recommend` keeps serving the banned profile to other users until their per-user cache expires.

## Live repro (today)

- Peter auto-banned at 23:33 after hitting the two-report threshold ([report-service:274](services/domain-4-moderation/report-service/lambda_function.py#L274))
- D1 profile-service processed `user.banned` → published `profile.banned` ([profile-service:377](services/domain-1-identity/profile-service/lambda_function.py#L377))
- D2 discovery-service received `profile.banned` and correctly deleted peter's row from `kismet-discovery` (verified in the table)
- D2 recommendation-service received the same event but only deleted `PK=USER#peter` rows
- kismet-recommendations still had:
  ```
  USER#<john>  SCORE#0050#<peter>  candidateUserId=<peter>
  ```
- Result: peter kept appearing in john's discover feed

Manually deleted that orphan row to unblock the demo; this PR is the permanent fix.

## Fix

After the existing PK-based query-delete, do a second pass:

```python
table.scan(FilterExpression=Attr('candidateUserId').eq(user_id), ...)
```

then batch-delete the matches. Logs both counters separately (`own=X orphan=Y`) so we can see each path in CloudWatch.

**Why scan, not a GSI?** The table has no GSI on `candidateUserId` and adding one is a CDK/infra change that needs deploy time we don't have before the demo. The table is small (bounded by active users × per-user cache size), so a filtered scan is the right tradeoff for now. If the user base grows, a GSI is the cleaner long-term fix.

**IAM:** `KismetService.grant_read_write_data` already includes `dynamodb:Scan`, so no policy change.

## Test plan

- [ ] After merge + redeploy, auto-ban a fresh test user via two reports
- [ ] Confirm `kismet-recommendations` scan for `candidateUserId=<banned>` returns 0 rows
- [ ] Confirm another user's `/recommend` response no longer includes the banned user