### PR TITLE
docs(readme): document enableActivityStream context flag requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ service-name/
 3. Read your service's README for setup instructions
 4. Deploy: `cd infra && npx cdk deploy <StackName> --app "python3 app.py"`
 
+> **Heads up — `enableActivityStream` context flag.** If the target AWS account already has D6's activity pipeline deployed (Kinesis stream `kismet-activity-stream` + `kismet-activity-firehose`), **every `cdk deploy` on that account must include `-c enableActivityStream=true`**, even when deploying an unrelated stack. `cdk.json` ships with the flag set to `false` (to keep the stream opt-in and avoid the ~$11/month Kinesis cost on fresh environments), and without the CLI override CDK will try to drift-correct `KismetShared` back to the no-stream state on every deploy, fail because `KismetDomain6` still imports the ActivityStream ARN, and auto-rollback. No damage, but your real deploy never runs. Example: `cdk deploy KismetDomain2 -c enableActivityStream=true`.
+
 ### User frontend (Next.js, Vercel)
 
 Local:


### PR DESCRIPTION
## Why

On accounts where D6's activity pipeline is deployed — which is every env that ran `cdk deploy KismetShared KismetDomain6 -c enableActivityStream=true` at least once — **every subsequent `cdk deploy` of any stack must include the flag**, even when the stack being deployed has nothing to do with D6.

If you omit the flag, CDK synthesizes `KismetShared` without the stream (the cdk.json default is `false`, kept that way to avoid ~\$11/month Kinesis cost on fresh environments), tries to remove `ActivityStreamArn` + related exports from the deployed stack, fails because `KismetDomain6` still imports them, and auto-rolls back. No damage, but the intended deploy never runs.

## What I ran into today

Deploying #162 (`cdk deploy KismetDomain2`) without the flag gave:

```
UPDATE_ROLLBACK_IN_PROGRESS | KismetShared
Delete canceled. Cannot delete export KismetShared:ExportsOutputRefActivityStream23E20E95A98A03E6
as it is in use by KismetDomain6.
```

Re-ran with `-c enableActivityStream=true` and it went through in 49s.

## Alternative considered

Setting `enableActivityStream: true` in `cdk.json` directly. Decided against — that would flip the default for fresh environments and quietly stand up a cost-bearing Kinesis stream. A note in the README is the lighter-weight fix.

## Test plan

- [x] Rendered README, the callout sits right below the `cdk deploy` line in Getting Started