### PR TITLE
test(ci): unhang cross-domain rec-cache test and fix date-flaky d6 stats test

### DIFF
--- a/services/domain-6-analytics/admin-dashboard-service/tests/test_lambda_function.py
+++ b/services/domain-6-analytics/admin-dashboard-service/tests/test_lambda_function.py
@@ -1,6 +1,7 @@
 import json
 import os
 import importlib
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import boto3
@@ -132,11 +133,16 @@ def _seed_message(aws, match_id, message_id, timestamp, **extra):
 
 class TestGetStats:
     def test_returns_stats(self, aws):
+        # get_stats filters matches/messages by "begins_with(... today)", where
+        # today is datetime.now(timezone.utc). Use a live "today" timestamp so
+        # the test is not date-sensitive (it was silently broken across UTC
+        # midnight — CI that ran minutes after midnight hit `0 == 1`).
+        today_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         _seed_profile(aws, "user-1")
         _seed_profile(aws, "user-2", status="banned")
         _seed_flagged(aws, "c-1")
-        _seed_match(aws, "match-1", "2026-04-17T12:00:00Z")
-        _seed_message(aws, "match-1", "msg-1", "2026-04-17T12:30:00Z")
+        _seed_match(aws, "match-1", today_iso)
+        _seed_message(aws, "match-1", "msg-1", today_iso)
         r = lambda_function.handler(http_event("GET", "/admin/stats"), {})
         assert r["statusCode"] == 200
         body = json.loads(r["body"])

--- a/tests/test_cross_domain_integration.py
+++ b/tests/test_cross_domain_integration.py
@@ -1113,6 +1113,12 @@ class TestUserDeletedEventChain(unittest.TestCase):
                         {"PK": "USER#user-alice", "SK": "SCORE#0080#user-charlie"},
                     ]
                 }
+                # Handler also calls scan() to purge orphan candidate rows in
+                # OTHER users' caches. Return an empty page with no
+                # LastEvaluatedKey so the scan loop terminates — without this
+                # the default MagicMock makes `.get("LastEvaluatedKey")` a
+                # truthy Mock and the loop hangs until the CI runner kills it.
+                mock_table.scan.return_value = {"Items": []}
                 mock_batch = MagicMock()
                 mock_table.batch_writer.return_value.__enter__ = MagicMock(return_value=mock_batch)
                 mock_table.batch_writer.return_value.__exit__ = MagicMock(return_value=False)
@@ -1121,6 +1127,7 @@ class TestUserDeletedEventChain(unittest.TestCase):
 
                 self.assertEqual(response["statusCode"], 200)
                 mock_table.query.assert_called_once()
+                mock_table.scan.assert_called_once()
 
     # ── Message service deletes conversation messages ─────────────────────────
 


### PR DESCRIPTION
## Summary

Two independent test fixes to clear red CI that landed after #162 was admin-merged without waiting on checks.

## 1. cross-domain-integration — `test_recommendation_service_deletes_cache_on_user_deleted` hang

### Root cause

The test patches `rec_mod.table` with a `MagicMock()` and seeds only `mock_table.query.return_value`. [#162](https://github.com/Kismet2026/Kismet/pull/162) added a second `table.scan(...)` loop to purge orphan candidate rows in other users' caches:

```python
while True:
    result = table.scan(...)
    with table.batch_writer() as batch: ...
    last_key = result.get('LastEvaluatedKey')
    if not last_key:
        break
```

Since `mock_table.scan` wasn't configured, calling it returned a new `MagicMock()`, and that mock's `.get("LastEvaluatedKey")` returned another truthy `MagicMock` — so `if not last_key` was never true, the loop never terminated, and the CI runner killed the job after ~15 min.

### Fix

```python
mock_table.scan.return_value = {"Items": []}
```

Also asserts `mock_table.scan.assert_called_once()` to lock in the cascade behavior going forward.

## 2. d6 admin-dashboard — `test_returns_stats` failed on `0 == 1`

### Root cause

The test seeded `matchedAt="2026-04-17T12:00:00Z"` but `get_stats` filters with `begins_with(matchedAt, today)` where `today = datetime.now(timezone.utc).strftime("%Y-%m-%d")`. The moment CI ran past UTC midnight the prefix no longer matched and the assertion flipped. The `messagesToday == 1` assertion below it had the same bug but we never got to it.

### Fix

Build `today_iso` dynamically from `datetime.now(timezone.utc)` in the seed calls so "today" in the seed and "today" in the filter are always the same day, regardless of when CI runs.

## Test plan

- [ ] Both Unit Tests and cross-domain-integration green on this branch's CI